### PR TITLE
feat(course): S3 Pandas 轉換解答版 notebook（含 RFM）

### DIFF
--- a/Special-Edition_python_DA/Python_DA_Course/M3_Pandas_Advanced/S3_pandas_transform_solution.ipynb
+++ b/Special-Edition_python_DA/Python_DA_Course/M3_Pandas_Advanced/S3_pandas_transform_solution.ipynb
@@ -1,0 +1,274 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# S3 — Pandas 轉換：groupby / merge / pivot（解答版）\n",
+    "\n",
+    "> **對應**：`S3_pandas_transform.ipynb` 課堂練習  \n",
+    "> **資料**：`orders_clean.csv` + `customers.csv` + `products.csv`  \n",
+    "> **說明**：本 notebook 只包含「課堂練習」的解答（送分題／核心題／挑戰題），並加上教學提示，方便學員對照檢查。\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## 解題策略\n",
+    "\n",
+    "- **送分題**：單表 `groupby + agg`，先確認資料欄位。\n",
+    "- **核心題**：先用 `merge` 合併三表，再針對題目做分組聚合。\n",
+    "- **挑戰題 (RFM)**：用 `groupby.agg` 的 **named aggregation** 一次產出 R/F/M 三個欄位，再 `merge` 顧客名稱。\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "DATA = '../datasets/ecommerce'\n",
+    "orders    = pd.read_csv(f'{DATA}/orders_clean.csv', parse_dates=['order_date'])\n",
+    "customers = pd.read_csv(f'{DATA}/customers.csv')\n",
+    "products  = pd.read_csv(f'{DATA}/products.csv')\n",
+    "\n",
+    "# 分析基底：三表合併（核心題與挑戰題會用到）\n",
+    "df = (\n",
+    "    orders\n",
+    "    .merge(customers, on='customer_id', how='left')\n",
+    "    .merge(products,  on='product_id',  how='left')\n",
+    ")\n",
+    "print('orders   :', orders.shape)\n",
+    "print('df (三表):', df.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 🟢 送分題 — 解答\n",
+    "\n",
+    "1. 每個 `customer_id` 的訂單總數\n",
+    "2. 平均單筆訂單金額\n",
+    "\n",
+    "**教學提示**：兩題都只需要 `orders` 單表。第 1 題用 `size()` 或 `count()`；第 2 題用 `mean()`。一次 `agg` 同時算完更漂亮。\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 解法 A：分開算\n",
+    "order_count = orders.groupby('customer_id').size()\n",
+    "mean_amount = orders.groupby('customer_id')['amount'].mean()\n",
+    "\n",
+    "print('每位顧客訂單數 (head):')\n",
+    "print(order_count.head())\n",
+    "print('\\n每位顧客平均金額 (head):')\n",
+    "print(mean_amount.head().round(2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 解法 B（推薦）：一次 agg 兩個指標，可讀性高\n",
+    "easy = (\n",
+    "    orders.groupby('customer_id')\n",
+    "          .agg(訂單數=('order_id', 'count'),\n",
+    "               平均金額=('amount', 'mean'))\n",
+    "          .round(2)\n",
+    "          .reset_index()\n",
+    ")\n",
+    "easy.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 🟡 核心題 — 解答\n",
+    "\n",
+    "用三表合併的 `df` 回答：\n",
+    "1. 哪個**商品類別**總營收最高？\n",
+    "2. **Gold** 等級的顧客一共下了多少筆訂單？金額多少？\n",
+    "3. 各**地區**的平均訂單金額？\n",
+    "\n",
+    "**教學提示**：\n",
+    "- Q1：`groupby('category')['amount'].sum()` 後 `sort_values` 或 `idxmax()` 抓最高者。\n",
+    "- Q2：先 `df[df['vip_level']=='Gold']` 篩選，再對 `amount` 同時算 `count + sum`。\n",
+    "- Q3：`groupby('region')['amount'].mean()`。\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Q1：商品類別總營收排名\n",
+    "category_rev = (\n",
+    "    df.groupby('category')['amount']\n",
+    "      .sum()\n",
+    "      .sort_values(ascending=False)\n",
+    ")\n",
+    "print('🏆 類別營收排名:')\n",
+    "print(category_rev)\n",
+    "print(f'\\n→ 營收最高類別：{category_rev.idxmax()}（{category_rev.max():,.0f}）')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Q2：Gold 等級顧客的訂單數與總金額\n",
+    "gold = df[df['vip_level'] == 'Gold']\n",
+    "gold_stat = gold['amount'].agg(['count', 'sum'])\n",
+    "print('💎 Gold 等級貢獻:')\n",
+    "print(f\"  訂單數：{int(gold_stat['count'])}\")\n",
+    "print(f\"  總金額：{gold_stat['sum']:,.0f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Q3：各地區的平均訂單金額\n",
+    "region_mean = (\n",
+    "    df.groupby('region')['amount']\n",
+    "      .mean()\n",
+    "      .round(2)\n",
+    "      .sort_values(ascending=False)\n",
+    ")\n",
+    "print('📍 各地區平均訂單金額:')\n",
+    "print(region_mean)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 🔴 挑戰題 — RFM 解答\n",
+    "\n",
+    "計算每位顧客的 **RFM**：\n",
+    "- **R**ecency：最近一次下單日期（`max(order_date)`）\n",
+    "- **F**requency：下單次數\n",
+    "- **M**onetary：總金額\n",
+    "\n",
+    "最後用 M 排序，取 Top 5 並附上顧客名字。\n",
+    "\n",
+    "**教學提示**：\n",
+    "1. **Recency 的實務做法**：真實專案中 Recency 通常是「距離今天（或 snapshot date，常設為資料集 `max(order_date) + 1 day`）的天數」，數值越小代表越近期。本題為了教學簡化，直接用 `max(order_date)` 當 R 欄位即可，後面註解區塊示範如何轉成天數版本。\n",
+    "2. **named aggregation**：`groupby.agg(R=('order_date','max'), F=('order_id','count'), M=('amount','sum'))` 一次產出三欄，語意最清楚。\n",
+    "3. **join 顧客名字**：用 `merge(customers[['customer_id','customer_name']], on='customer_id', how='left')` 把名字貼上來。\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Step 1：用 named aggregation 一次算出 R / F / M\n",
+    "rfm = (\n",
+    "    orders.groupby('customer_id')\n",
+    "          .agg(\n",
+    "              R=('order_date', 'max'),\n",
+    "              F=('order_id',   'count'),\n",
+    "              M=('amount',     'sum'),\n",
+    "          )\n",
+    "          .reset_index()\n",
+    ")\n",
+    "print('RFM 形狀:', rfm.shape)\n",
+    "rfm.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Step 2：merge 顧客名字\n",
+    "rfm_named = rfm.merge(\n",
+    "    customers[['customer_id', 'customer_name']],\n",
+    "    on='customer_id',\n",
+    "    how='left',\n",
+    ")\n",
+    "\n",
+    "# Step 3：用 M 排序，取 Top 5\n",
+    "top5 = (\n",
+    "    rfm_named\n",
+    "    .sort_values('M', ascending=False)\n",
+    "    .head(5)\n",
+    "    .reset_index(drop=True)\n",
+    "    [['customer_id', 'customer_name', 'R', 'F', 'M']]\n",
+    ")\n",
+    "print('🏆 RFM Top 5 顧客（依 Monetary 排序）:')\n",
+    "top5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Bonus：把 Recency 轉成「距離 snapshot date 的天數」\n",
+    "# 實務常見做法：snapshot = max(order_date) + 1 day，避免最近一單的 Recency = 0\n",
+    "snapshot = orders['order_date'].max() + pd.Timedelta(days=1)\n",
+    "print('snapshot date:', snapshot.date())\n",
+    "\n",
+    "rfm_days = rfm_named.copy()\n",
+    "rfm_days['R_days'] = (snapshot - rfm_days['R']).dt.days\n",
+    "rfm_days = rfm_days[['customer_id', 'customer_name', 'R_days', 'F', 'M']]\n",
+    "rfm_days.sort_values('M', ascending=False).head(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 重點回顧\n",
+    "\n",
+    "| 題型 | 核心技巧 |\n",
+    "|---|---|\n",
+    "| 送分題 | `groupby + agg` 一次多指標 |\n",
+    "| 核心題 | 先 `merge` 再 `groupby`；`idxmax()` 抓冠軍 |\n",
+    "| RFM | named aggregation + `merge` 補欄位；snapshot date 轉天數 |\n",
+    "\n",
+    "**做完這張 notebook 你應該能回答**：\n",
+    "- 為什麼 RFM 要用 snapshot date，而不是直接用今天？  \n",
+    "  → 確保分析結果可重現（reproducible），不會隨著「今天」改變；同時避免最近一筆訂單 R=0 造成的除零/分箱問題。\n",
+    "- `groupby.agg(新欄=('原欄','func'))` 比傳 dict 好在哪？  \n",
+    "  → 語意更清楚、欄名直接命名、不會產生 MultiIndex，後續處理更簡單。\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- 新增 `S3_pandas_transform_solution.ipynb`，對應 M3/S3 課堂練習
- 包含送分題（訂單數、平均金額）、核心題（類別營收、Gold 等級、地區平均）、挑戰題 RFM
- RFM 使用 `groupby.agg` named aggregation + `merge` 補顧客名稱；附 snapshot date 天數版本 bonus

## Test plan
- [x] `ast.parse` 通過全部 code cells
- [ ] 於完整環境執行（需先產出 `orders_clean.csv`，由 S2 notebook 輸出）