### PR TITLE
feat(course): S2 Pandas I/O 與清理解答版 notebook

### DIFF
--- a/Special-Edition_python_DA/Python_DA_Course/M2_Pandas_Basic/S2_pandas_io_cleaning_solution.ipynb
+++ b/Special-Edition_python_DA/Python_DA_Course/M2_Pandas_Basic/S2_pandas_io_cleaning_solution.ipynb
@@ -1,0 +1,291 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# S2 — Pandas I/O 與資料清理（解答版）\n",
+    "\n",
+    "> **本篇為解答版 (Answer Key)**，建議先完成 `S2_pandas_io_cleaning.ipynb` 的練習後再對照。\n",
+    "> \n",
+    "> ⚠️ **請先自己動手嘗試**，直接看答案學不到東西。卡關超過 15 分鐘再翻解答。\n",
+    "\n",
+    "---\n",
+    "\n",
+    "本解答版包含：\n",
+    "- 🟢 送分題：DataFrame 基本探索\n",
+    "- 🟡 核心題：`orders_raw.csv` 清理 + 回答 3 個問題\n",
+    "- 🔴 挑戰題：`clean_orders(path)` 可重用函式\n",
+    "- 💡 教學提示：常見陷阱與最佳實務"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "# 同 S2 使用相對路徑（notebook 位於 M2_Pandas_Basic/ 之下）\n",
+    "DATA = '../datasets/ecommerce/orders_raw.csv'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 🟢 送分題 — DataFrame 基本探索\n",
+    "\n",
+    "**題目**：建立下面這個 DataFrame，然後：\n",
+    "1. 用 `.head(2)` 看前兩列\n",
+    "2. 用 `.dtypes` 查看型別\n",
+    "3. 取出 `price` 這個 column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ 解答\n",
+    "practice = pd.DataFrame({\n",
+    "    'item':  ['Apple', 'Banana', 'Cherry', 'Durian'],\n",
+    "    'price': [50, 20, 150, 300],\n",
+    "    'stock': [10, 50, 5, 2],\n",
+    "})\n",
+    "\n",
+    "# (1) 前兩列 —— head(n) 是快速檢視資料的第一招\n",
+    "print('--- practice.head(2) ---')\n",
+    "print(practice.head(2))\n",
+    "\n",
+    "# (2) 每欄型別 —— 拿到新資料一定要先看型別，很多 bug 都是型別不對造成的\n",
+    "print('\\n--- practice.dtypes ---')\n",
+    "print(practice.dtypes)\n",
+    "\n",
+    "# (3) 取出 price 欄 —— 單括號回傳 Series（一維），雙括號才是 DataFrame（二維）\n",
+    "print('\\n--- practice[\"price\"] (Series) ---')\n",
+    "print(practice['price'])\n",
+    "print('\\n型別:', type(practice['price']).__name__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "💡 **教學提示（送分題）**：\n",
+    "- `df['col']` → 回傳 **Series**（一維）\n",
+    "- `df[['col']]` → 回傳 **DataFrame**（二維，只有一欄）\n",
+    "- 很多學生會困惑為什麼 `df[['a','b']]` 要兩層中括號 —— 因為外層是 `__getitem__`，內層是 list。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 🟡 核心題 — 清理 orders_raw.csv 並回答問題\n",
+    "\n",
+    "**題目**：重新讀一次 `orders_raw.csv`，完成清理並回答：\n",
+    "1. 清理後總共有多少筆訂單？\n",
+    "2. `amount` 的平均值是多少？\n",
+    "3. amount > 5000 的訂單有幾筆？"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ 解答 —— 逐步清理並回答三個問題\n",
+    "\n",
+    "# Step 0: 重新讀檔（注意：每次從原始檔開始，避免污染）\n",
+    "df = pd.read_csv(DATA)\n",
+    "original_rows = df.shape[0]\n",
+    "print(f'原始資料: {original_rows} 筆')\n",
+    "\n",
+    "# Step 1: 欄名標準化 —— 去空白 + 轉小寫（解決 'Order_ID ' 尾端空格問題）\n",
+    "df.columns = df.columns.str.strip().str.lower()\n",
+    "\n",
+    "# Step 2: amount 字串轉數字\n",
+    "#   順序很重要：先 astype(str) → 再 replace → 最後 astype(float)\n",
+    "#   為什麼要先 astype(str)？因為有些列本來就是數字，.str 取值器只對字串有效\n",
+    "df['amount'] = (\n",
+    "    df['amount']\n",
+    "    .astype(str)\n",
+    "    .str.replace('$', '', regex=False)\n",
+    "    .str.replace(',', '', regex=False)\n",
+    "    .astype(float)\n",
+    ")\n",
+    "\n",
+    "# Step 3: 日期欄轉型 —— errors='coerce' 讓無法解析的變 NaT，而不是整個報錯\n",
+    "df['order_date'] = pd.to_datetime(df['order_date'], errors='coerce')\n",
+    "\n",
+    "# Step 4: 缺值處理\n",
+    "df = df.dropna(subset=['order_date'])                    # 沒日期無法做時序，直接丟\n",
+    "df['qty'] = df['qty'].fillna(df['qty'].median())         # qty 用中位數補（比 mean 穩健）\n",
+    "\n",
+    "# Step 5: 去重\n",
+    "df = df.drop_duplicates()\n",
+    "\n",
+    "# ---- 回答問題 ----\n",
+    "q1_total = len(df)\n",
+    "q2_mean = df['amount'].mean()\n",
+    "q3_big_orders = (df['amount'] > 5000).sum()\n",
+    "\n",
+    "print(f'\\n【Q1】清理後總筆數: {q1_total} 筆（原 {original_rows} → {q1_total}）')\n",
+    "print(f'【Q2】amount 平均值: {q2_mean:.2f}')\n",
+    "print(f'【Q3】amount > 5000 的訂單: {q3_big_orders} 筆')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "💡 **教學提示（核心題）**：\n",
+    "- **忘記 `errors='coerce'`** 是最常見錯誤 → `to_datetime` 碰到爛資料會直接拋例外，整個 pipeline 停擺。加上 `coerce` 後無法解析的會變 `NaT`（Not a Time），再用 `dropna` 處理。\n",
+    "- **型別轉換順序**：如果 amount 欄混有 `int` 和 `str`，直接 `.str.replace` 會在 int 那格回傳 `NaN`。正解是先 `.astype(str)` 把全欄統一成字串再處理。\n",
+    "- **布林遮罩計數**：`(df['amount'] > 5000).sum()` 比 `len(df[df['amount']>5000])` 更簡潔，因為 `True=1, False=0`。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 🔴 挑戰題 — 封裝成可重用函式 `clean_orders(path)`\n",
+    "\n",
+    "**題目**：把清理邏輯封裝成函式，輸入髒檔案路徑、輸出乾淨 DataFrame，並印出清理摘要。\n",
+    "\n",
+    "**為什麼要封裝？**\n",
+    "> 未來每週收到新的訂單檔，只要 `clean_orders('2026-04.csv')` 就清好了 —— 這就是 **DE 的 reusable pipeline**。一次寫好、千次呼叫。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ 解答：可重用的訂單清理函式\n",
+    "\n",
+    "def clean_orders(path: str) -> pd.DataFrame:\n",
+    "    \"\"\"清理訂單原始檔，回傳乾淨 DataFrame。\n",
+    "\n",
+    "    處理步驟：\n",
+    "      1. 欄名 strip + lower\n",
+    "      2. amount 移除 $ 與 , 後轉 float\n",
+    "      3. order_date 轉 datetime（errors='coerce'）\n",
+    "      4. 丟棄無日期的列\n",
+    "      5. qty 用中位數補值\n",
+    "      6. 移除完全重複的列\n",
+    "\n",
+    "    參數\n",
+    "    ----\n",
+    "    path : str\n",
+    "        訂單 CSV 檔案路徑。\n",
+    "\n",
+    "    回傳\n",
+    "    ----\n",
+    "    pd.DataFrame\n",
+    "        清理後的訂單 DataFrame。\n",
+    "    \"\"\"\n",
+    "    # --- Extract：讀檔 ---\n",
+    "    df = pd.read_csv(path)\n",
+    "    n_before = len(df)  # 記錄原始筆數，用於最後印摘要\n",
+    "\n",
+    "    # --- Transform Step 1: 欄名標準化 ---\n",
+    "    # strip() 去掉頭尾空白、lower() 全轉小寫 → 避免 'Order_ID ' 這類陷阱\n",
+    "    df.columns = df.columns.str.strip().str.lower()\n",
+    "\n",
+    "    # --- Transform Step 2: amount 字串→數字 ---\n",
+    "    # 先 astype(str) 統一型別，再剝除 $ 和 ,，最後 cast 成 float\n",
+    "    df['amount'] = (\n",
+    "        df['amount']\n",
+    "        .astype(str)\n",
+    "        .str.replace('$', '', regex=False)\n",
+    "        .str.replace(',', '', regex=False)\n",
+    "        .astype(float)\n",
+    "    )\n",
+    "\n",
+    "    # --- Transform Step 3: 日期轉型（errors='coerce' 是關鍵！）---\n",
+    "    df['order_date'] = pd.to_datetime(df['order_date'], errors='coerce')\n",
+    "\n",
+    "    # --- Transform Step 4: 缺值處理 ---\n",
+    "    df = df.dropna(subset=['order_date'])              # 無日期 → 丟\n",
+    "    df['qty'] = df['qty'].fillna(df['qty'].median())   # qty 缺 → 中位數補\n",
+    "\n",
+    "    # --- Transform Step 5: 去重 ---\n",
+    "    df = df.drop_duplicates()\n",
+    "\n",
+    "    # --- 印出 1 行清理摘要 ---\n",
+    "    n_after = len(df)\n",
+    "    print(f'清理完成：原 {n_before} 筆 → {n_after} 筆')\n",
+    "\n",
+    "    return df\n",
+    "\n",
+    "\n",
+    "# 測試函式\n",
+    "clean = clean_orders(DATA)\n",
+    "print('\\n--- 清理後 dtypes ---')\n",
+    "print(clean.dtypes)\n",
+    "print('\\n--- 清理後 head(3) ---')\n",
+    "print(clean.head(3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "💡 **教學提示（挑戰題）—— 封裝函式的常見陷阱**：\n",
+    "\n",
+    "1. **不要改動傳入的 DataFrame**：函式內操作的是 `pd.read_csv` 回傳的新物件，不會影響外部變數（符合不可變性原則）。\n",
+    "2. **`errors='coerce'` 一定要加**：沒加的話，只要一列日期格式錯誤就整個 pipeline 炸掉。\n",
+    "3. **`.str.replace` vs 數字轉換順序**：若先 `astype(float)` 再 `.str.replace` 會報錯，因為 float 沒有 `.str` 取值器。記住順序：**先清字串，再轉型別**。\n",
+    "4. **回傳值**：函式**一定要 `return df`**，不然呼叫端拿到 `None`。這是新手最常犯的錯誤之一。\n",
+    "5. **`drop_duplicates` 的時機**：放在最後，因為前面的清理可能讓原本看似不同的列變成相同（例如日期格式標準化後）。\n",
+    "6. **用 median 而非 mean 補 qty**：中位數對極端值更穩健，不會被 1 筆異常大單拉偏。\n",
+    "\n",
+    "### 🚀 進階延伸（給學有餘力的同學）\n",
+    "- 加上 `logging` 取代 `print`，方便在 production 追蹤\n",
+    "- 加上 schema 驗證（例如用 `pandera`）確保輸出欄位和型別都正確\n",
+    "- 把函式寫成 class `OrderCleaner`，支援更多可配置參數（例如自訂缺值策略）"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 🎯 解答版小結\n",
+    "\n",
+    "| 題目 | 關鍵技巧 | 常見錯誤 |\n",
+    "|---|---|---|\n",
+    "| 🟢 送分題 | `head` / `dtypes` / 欄位選取 | 混淆 `df['x']` 與 `df[['x']]` |\n",
+    "| 🟡 核心題 | strip → 字串清洗 → 日期轉型 → dropna | 忘記 `errors='coerce'` |\n",
+    "| 🔴 挑戰題 | 封裝為可重用函式 | 忘記 `return df`、型別順序錯誤 |\n",
+    "\n",
+    "**核心心法**：拿到髒資料 → `head/info/isna` 掃一遍 → 逐欄處理 → 封裝成函式 → 未來只呼叫一行。\n",
+    "\n",
+    "下一節 **S3** 會用這份清乾淨的資料做**三表 join** 與**分組聚合**，正式進入商業洞察階段。"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- 新增 S2 資料清理單元的教師解答版 notebook
- 涵蓋送分題（DataFrame 基本探索）、核心題（orders_raw 清理 + 3 問）、挑戰題（`clean_orders(path)` 可重用函式）
- 每題附帶「教學提示」說明常見陷阱（`errors='coerce'`、型別轉換順序、忘記 `return` 等）

## Test plan
- [x] E2E: `ast.parse` 所有 code cells 語法通過
- [x] 相對路徑 `../datasets/ecommerce/orders_raw.csv` 與 S2 一致
- [x] `clean_orders` 函式包含所有要求步驟（strip+lower、$/, 處理、to_datetime coerce、dropna、median fill、drop_duplicates、return、摘要列印）
- [x] Header 明確標記為解答版並提醒學生先自行嘗試

🤖 Generated with [Claude Code](https://claude.com/claude-code)