### PR TITLE
feat(course): S4 時間序列 + EDA 解答版 notebook

### DIFF
--- a/Special-Edition_python_DA/Python_DA_Course/M3_Pandas_Advanced/S4_timeseries_eda_solution.ipynb
+++ b/Special-Edition_python_DA/Python_DA_Course/M3_Pandas_Advanced/S4_timeseries_eda_solution.ipynb
@@ -1,0 +1,290 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# S4 — 時間序列 + EDA 實戰（解答版）\n",
+    "\n",
+    "> **對應教材**：`S4_timeseries_eda.ipynb`\n",
+    "> **說明**：本檔為課堂練習的參考解答，含完整程式碼與重點教學提示。\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## 使用說明\n",
+    "\n",
+    "1. 請先執行 S3 產生 `../datasets/ecommerce/orders_enriched.csv`\n",
+    "2. 建議先自己嘗試作答，再對照本檔解答\n",
+    "3. 解答注重「能跑、能懂、符合 DA 日常寫法」，不追求最短一行\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "df = pd.read_csv(\n",
+    "    '../datasets/ecommerce/orders_enriched.csv',\n",
+    "    parse_dates=['order_date'],\n",
+    ")\n",
+    "\n",
+    "# 沿用 S4 的時間衍生欄位\n",
+    "df['year']     = df['order_date'].dt.year\n",
+    "df['month']    = df['order_date'].dt.month\n",
+    "df['weekday']  = df['order_date'].dt.day_name()\n",
+    "df['year_mon'] = df['order_date'].dt.to_period('M')\n",
+    "\n",
+    "print('資料形狀:', df.shape)\n",
+    "print('日期範圍:', df['order_date'].min(), '~', df['order_date'].max())\n",
+    "df.head(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 🟢 送分題解答\n",
+    "\n",
+    "### Q1. 每個月份 (1~12) 的平均訂單金額\n",
+    "\n",
+    "**思路**：用 `groupby('month')` 後對 `amount` 取 `mean`。這裡的 `month` 是 1~12 的整數（不分年），代表「同一個月份」的平均行為。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "avg_by_month = df.groupby('month')['amount'].mean().round(1)\n",
+    "print('📊 各月份平均訂單金額:')\n",
+    "print(avg_by_month)\n",
+    "print(f'\\n🏆 平均金額最高月份: {avg_by_month.idxmax()} 月 (NT$ {avg_by_month.max():,.1f})')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q2. 訂單數最多的前 3 天\n",
+    "\n",
+    "**思路**：先取 `order_date` 的日期部分（丟掉時間），用 `value_counts()` 取前 3。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "top3_days = df['order_date'].dt.date.value_counts().head(3)\n",
+    "print('📅 訂單數最多的前 3 天:')\n",
+    "print(top3_days)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 🟡 核心題解答\n",
+    "\n",
+    "### Q1. 每月訂單數的 3 個月移動平均\n",
+    "\n",
+    "**思路**：\n",
+    "1. 先用 `groupby('year_mon')` 或 `resample('ME')` 算出每月訂單數\n",
+    "2. 再用 `.rolling(window=3).mean()` 取 3 個月移動平均\n",
+    "\n",
+    "> **教學提示：`resample` vs `groupby(dt.to_period)`**\n",
+    "> - `resample('ME')`：需要 datetime index，會自動補上缺月（空月會變 0 或 NaN），適合做連續時序\n",
+    "> - `groupby(year_mon)`：不需要 index，結果是 PeriodIndex，**沒有資料的月份不會出現**\n",
+    "> - 做移動平均、趨勢圖用 `resample` 比較安全（避免缺月被跳過造成誤差）"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 用 resample 版本（推薦：保證月份連續）\n",
+    "ts = df.set_index('order_date').sort_index()\n",
+    "monthly_orders = ts['order_id'].resample('ME').count()\n",
+    "monthly_orders_ma3 = monthly_orders.rolling(window=3).mean().round(1)\n",
+    "\n",
+    "result = pd.DataFrame({\n",
+    "    '每月訂單數': monthly_orders,\n",
+    "    '3個月移動平均': monthly_orders_ma3,\n",
+    "})\n",
+    "print('📈 每月訂單數 + 3 個月移動平均:')\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q2. 2025 Q4 (10~12 月) 的總營收\n",
+    "\n",
+    "**思路**：用 boolean mask 篩選日期區間 `2025-10-01` ~ `2025-12-31`，再對 `amount` 取 `sum`。\n",
+    "\n",
+    "另一種寫法是用 `df['order_date'].dt.quarter == 4` + `year == 2025`，兩種都可。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 寫法 1：用日期區間篩選（最直觀）\n",
+    "mask = (df['order_date'] >= '2025-10-01') & (df['order_date'] <= '2025-12-31')\n",
+    "q4_revenue = df.loc[mask, 'amount'].sum()\n",
+    "print(f'💰 2025 Q4 總營收: NT$ {q4_revenue:,.0f}')\n",
+    "\n",
+    "# 寫法 2：用 dt.quarter（更 Pythonic）\n",
+    "q4_revenue_v2 = df.loc[\n",
+    "    (df['year'] == 2025) & (df['order_date'].dt.quarter == 4),\n",
+    "    'amount'\n",
+    "].sum()\n",
+    "print(f'💰 2025 Q4 總營收 (驗證): NT$ {q4_revenue_v2:,.0f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q3. 每個品類的訂單金額中位數（排序）\n",
+    "\n",
+    "**思路**：`groupby('category')['amount'].median()`，再 `sort_values(ascending=False)`。\n",
+    "\n",
+    "> **為什麼用中位數而不是平均？** 中位數對極端值不敏感，更能反映「典型」客單價；平均數容易被少數大單拉高。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "median_by_cat = (\n",
+    "    df.groupby('category')['amount']\n",
+    "      .median()\n",
+    "      .sort_values(ascending=False)\n",
+    "      .round(1)\n",
+    ")\n",
+    "print('📊 各品類訂單金額中位數（由高到低）:')\n",
+    "print(median_by_cat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 🔴 挑戰題解答 — 月度經營報告\n",
+    "\n",
+    "**需求回顧**：每月一列，包含「月份 / 總訂單數 / 總營收 / 活躍顧客數 / 客單價 / MoM 成長率(%)」。\n",
+    "\n",
+    "**解題步驟**：\n",
+    "1. `groupby('year_mon')` + `.agg({...})` 一次算出多個聚合\n",
+    "2. 重新命名欄位為中文（對上老闆的月報表）\n",
+    "3. 用 `總營收 / 總訂單數` 算客單價\n",
+    "4. 用 `.pct_change() * 100` 算 MoM 成長率\n",
+    "5. 依月份排序（PeriodIndex 本身就是可排序的）\n",
+    "\n",
+    "> **教學提示：`pct_change()` 的陷阱**\n",
+    "> - 第一列一定是 `NaN`（沒有上一個月可以比）\n",
+    "> - 要確保資料**已按時間排序**，否則算出來的成長率是亂的\n",
+    "> - 單位是「倍數」不是「百分比」，要顯示成百分比要 `* 100`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Step 1: 一次聚合多個欄位\n",
+    "monthly_report = (\n",
+    "    df.groupby('year_mon')\n",
+    "      .agg(\n",
+    "          總訂單數=('order_id', 'count'),\n",
+    "          總營收=('amount', 'sum'),\n",
+    "          活躍顧客數=('customer_id', 'nunique'),\n",
+    "      )\n",
+    "      .sort_index()  # 先確保按月份排序，pct_change 才正確\n",
+    ")\n",
+    "\n",
+    "# Step 2: 算客單價\n",
+    "monthly_report['客單價'] = (\n",
+    "    monthly_report['總營收'] / monthly_report['總訂單數']\n",
+    ").round(1)\n",
+    "\n",
+    "# Step 3: 算 MoM 成長率 (%)\n",
+    "monthly_report['MoM成長率(%)'] = (\n",
+    "    monthly_report['總營收'].pct_change() * 100\n",
+    ").round(2)\n",
+    "\n",
+    "# Step 4: 把 index 變成一個「月份」欄位，輸出更像報表\n",
+    "monthly_report = monthly_report.reset_index().rename(columns={'year_mon': '月份'})\n",
+    "monthly_report['月份'] = monthly_report['月份'].astype(str)\n",
+    "\n",
+    "print('📋 月度經營報告:')\n",
+    "monthly_report"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 延伸：找出成長率最高/最低的月份（忽略第一個月的 NaN）\n",
+    "valid = monthly_report.dropna(subset=['MoM成長率(%)'])\n",
+    "best_mom  = valid.loc[valid['MoM成長率(%)'].idxmax()]\n",
+    "worst_mom = valid.loc[valid['MoM成長率(%)'].idxmin()]\n",
+    "\n",
+    "print(f\"🚀 成長最猛: {best_mom['月份']}  (+{best_mom['MoM成長率(%)']}%)\")\n",
+    "print(f\"📉 衰退最多: {worst_mom['月份']}  ({worst_mom['MoM成長率(%)']}%)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 解題回顧\n",
+    "\n",
+    "| 題目 | 關鍵 API | 常見錯誤 |\n",
+    "|---|---|---|\n",
+    "| 送分 Q1 | `groupby('month').mean()` | 把 `year_mon` 和 `month` 搞混 |\n",
+    "| 送分 Q2 | `dt.date.value_counts()` | 忘了 `.dt.date`，結果每筆時間戳都是 unique |\n",
+    "| 核心 Q1 | `resample('ME') + rolling(3)` | 用 `groupby` 跳過缺月導致移動平均失準 |\n",
+    "| 核心 Q2 | boolean mask + `sum()` | 日期字串寫錯格式 |\n",
+    "| 核心 Q3 | `groupby.median().sort_values()` | 用 mean 被極端值干擾 |\n",
+    "| 挑戰題 | `agg + pct_change` | 忘了先 `sort_index` 導致 MoM 錯誤 |\n",
+    "\n",
+    "**下一步**：S5 會把這份月報表畫成長條圖 + 折線圖，變成可以直接塞進簡報的視覺化成果。\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- 新增 `S4_timeseries_eda_solution.ipynb`，對應 M3 S4 課堂練習的完整解答
- 涵蓋送分題（月份平均金額、Top 3 訂單日）、核心題（3 個月移動平均、Q4 營收、品類中位數）、挑戰題（月度經營報告含 MoM 成長率）
- 加入 `resample` vs `groupby(dt.to_period)` 取捨、`pct_change` 陷阱等教學提示

## Test plan
- [x] `json.load` + `ast.parse` 通過（所有 code cell 語法正確）
- [ ] 課程助教執行 S3 產生 `orders_enriched.csv` 後可順利 Run All