### PR TITLE
feat(course): S5 視覺化解答版 notebook（含 Electronics 儀表板）

### DIFF
--- a/Special-Edition_python_DA/Python_DA_Course/M4_Matplotlib_Seaborn_Basic/S5_visualization_essentials_solution.ipynb
+++ b/Special-Edition_python_DA/Python_DA_Course/M4_Matplotlib_Seaborn_Basic/S5_visualization_essentials_solution.ipynb
@@ -1,0 +1,326 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# S5 — 視覺化精華：課堂練習【解答版】\n",
+    "\n",
+    "> **對應**：`S5_visualization_essentials.ipynb` 課堂練習段  \n",
+    "> **資料**：`orders_enriched.csv`（S3 產出）  \n",
+    "> **重點**：送分題 / 核心題 / 挑戰題（Electronics 迷你儀表板）完整解答\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## 教學提示\n",
+    "\n",
+    "- **Seaborn 的 `palette` 警告**：新版 seaborn 若只給 `palette=` 而不給 `hue=`，會噴 `FutureWarning`。正確做法是把分組欄位丟給 `hue`，若圖例重複再用 `legend=False` 隱藏。\n",
+    "- **`plt.tight_layout()`**：subplot 邊界擠在一起時必加，能自動調整間距避免標題／軸標籤重疊。\n",
+    "- **中文字型**：`plt.rcParams['axes.unicode_minus'] = False` 讓負號正常顯示；本節標題皆用英文，避免字型缺字問題。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "\n",
+    "plt.rcParams['axes.unicode_minus'] = False\n",
+    "sns.set_theme(style='whitegrid')\n",
+    "\n",
+    "df = pd.read_csv(\n",
+    "    '../datasets/ecommerce/orders_enriched.csv',\n",
+    "    parse_dates=['order_date'],\n",
+    ")\n",
+    "df['month'] = df['order_date'].dt.to_period('M').astype(str)\n",
+    "print('資料形狀:', df.shape)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 🟢 送分題\n",
+    "\n",
+    "1. 各品類的**訂單數**長條圖\n",
+    "2. `amount` 的**直方圖**（`sns.histplot`）"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 送分題 1：各品類的訂單數長條圖\n",
+    "cat_counts = df['category'].value_counts().reset_index()\n",
+    "cat_counts.columns = ['category', 'order_count']\n",
+    "\n",
+    "plt.figure(figsize=(8, 4))\n",
+    "sns.barplot(\n",
+    "    data=cat_counts,\n",
+    "    x='category', y='order_count',\n",
+    "    hue='category', palette='viridis', legend=False,\n",
+    ")\n",
+    "plt.title('Order Count by Category', fontweight='bold')\n",
+    "plt.xlabel('Category')\n",
+    "plt.ylabel('Order Count')\n",
+    "\n",
+    "# 柱子上標數字\n",
+    "for i, v in enumerate(cat_counts['order_count']):\n",
+    "    plt.text(i, v, f'{v:,}', ha='center', va='bottom', fontsize=10)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 送分題 2：amount 的直方圖\n",
+    "plt.figure(figsize=(9, 4))\n",
+    "sns.histplot(data=df, x='amount', bins=30, kde=True, color='steelblue')\n",
+    "plt.title('Order Amount Distribution', fontweight='bold')\n",
+    "plt.xlabel('Amount (NT$)')\n",
+    "plt.ylabel('Frequency')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**解題重點**：\n",
+    "- 訂單數 = `value_counts()` 或 `groupby().size()`；不要跟 `sum(amount)` 搞混。\n",
+    "- `histplot` 加 `kde=True` 會疊一條密度曲線，能更直觀看出分布形狀（是否右偏）。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 🟡 核心題\n",
+    "\n",
+    "1. 比較 **North vs South** 兩地區的月度營收趨勢（兩條線的折線圖）\n",
+    "2. 不同 **vip_level** 的客單價箱型圖"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 核心題 1：North vs South 月度營收比較折線圖\n",
+    "ns_df = df[df['region'].isin(['North', 'South'])]\n",
+    "monthly_ns = (\n",
+    "    ns_df.groupby(['month', 'region'])['amount']\n",
+    "    .sum()\n",
+    "    .reset_index()\n",
+    ")\n",
+    "\n",
+    "plt.figure(figsize=(10, 4))\n",
+    "sns.lineplot(\n",
+    "    data=monthly_ns,\n",
+    "    x='month', y='amount',\n",
+    "    hue='region', marker='o', linewidth=2,\n",
+    ")\n",
+    "plt.title('Monthly Revenue: North vs South', fontweight='bold')\n",
+    "plt.xlabel('Month')\n",
+    "plt.ylabel('Revenue (NT$)')\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.legend(title='Region')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 核心題 2：不同 vip_level 的客單價箱型圖\n",
+    "plt.figure(figsize=(9, 5))\n",
+    "sns.boxplot(\n",
+    "    data=df,\n",
+    "    x='vip_level', y='amount',\n",
+    "    hue='vip_level', palette='Set3', legend=False,\n",
+    ")\n",
+    "plt.title('Order Amount Distribution by VIP Level', fontweight='bold')\n",
+    "plt.xlabel('VIP Level')\n",
+    "plt.ylabel('Amount (NT$)')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**解題重點**：\n",
+    "- 兩條線折線圖：最簡單是用 `hue='region'`，seaborn 會自動分色、建立圖例。\n",
+    "- 用 `isin(['North', 'South'])` 先過濾，避免其他地區也被畫進來。\n",
+    "- 箱型圖比較 vip 等級時，能一次看到中位數差異 + 是否有大筆離群訂單。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 🔴 挑戰題 — Electronics 迷你儀表板\n",
+    "\n",
+    "做一份**只屬於 Electronics 品類**的 2×2 儀表板：\n",
+    "\n",
+    "| 位置 | 圖 |\n",
+    "|---|---|\n",
+    "| (0,0) | 月度趨勢折線圖 |\n",
+    "| (0,1) | 地區營收排名長條圖 |\n",
+    "| (1,0) | 商品 Top 5 長條圖 |\n",
+    "| (1,1) | 金額分布直方圖 |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 先過濾：只留 Electronics\n",
+    "elec = df[df['category'] == 'Electronics'].copy()\n",
+    "print('Electronics 訂單數:', len(elec))\n",
+    "print('Electronics 總營收:', f\"NT$ {elec['amount'].sum():,.0f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 預先準備四張圖需要的資料\n",
+    "elec_monthly = elec.groupby('month')['amount'].sum().reset_index()\n",
+    "elec_region = (\n",
+    "    elec.groupby('region')['amount']\n",
+    "    .sum()\n",
+    "    .sort_values(ascending=False)\n",
+    "    .reset_index()\n",
+    ")\n",
+    "elec_top5 = (\n",
+    "    elec.groupby('product_name')['amount']\n",
+    "    .sum()\n",
+    "    .sort_values(ascending=False)\n",
+    "    .head(5)\n",
+    "    .reset_index()\n",
+    ")\n",
+    "\n",
+    "# 2x2 儀表板\n",
+    "fig, axes = plt.subplots(2, 2, figsize=(14, 9))\n",
+    "fig.suptitle('Electronics Category Dashboard', fontsize=16, fontweight='bold')\n",
+    "\n",
+    "# (0,0) 月度趨勢\n",
+    "sns.lineplot(\n",
+    "    data=elec_monthly, x='month', y='amount',\n",
+    "    marker='o', linewidth=2, color='#1f77b4', ax=axes[0, 0],\n",
+    ")\n",
+    "axes[0, 0].set_title('Monthly Revenue Trend')\n",
+    "axes[0, 0].set_xlabel('Month')\n",
+    "axes[0, 0].set_ylabel('Revenue (NT$)')\n",
+    "axes[0, 0].tick_params(axis='x', rotation=45)\n",
+    "\n",
+    "# (0,1) 地區排名\n",
+    "sns.barplot(\n",
+    "    data=elec_region, x='region', y='amount',\n",
+    "    hue='region', palette='viridis', legend=False, ax=axes[0, 1],\n",
+    ")\n",
+    "axes[0, 1].set_title('Revenue by Region')\n",
+    "axes[0, 1].set_xlabel('Region')\n",
+    "axes[0, 1].set_ylabel('Revenue (NT$)')\n",
+    "for i, v in enumerate(elec_region['amount']):\n",
+    "    axes[0, 1].text(i, v, f'{v:,.0f}', ha='center', va='bottom', fontsize=9)\n",
+    "\n",
+    "# (1,0) 商品 Top 5\n",
+    "sns.barplot(\n",
+    "    data=elec_top5, y='product_name', x='amount',\n",
+    "    hue='product_name', palette='magma', legend=False, ax=axes[1, 0],\n",
+    ")\n",
+    "axes[1, 0].set_title('Top 5 Products')\n",
+    "axes[1, 0].set_xlabel('Revenue (NT$)')\n",
+    "axes[1, 0].set_ylabel('Product')\n",
+    "\n",
+    "# (1,1) 金額分布\n",
+    "sns.histplot(\n",
+    "    data=elec, x='amount', bins=25, kde=True,\n",
+    "    color='#d62728', ax=axes[1, 1],\n",
+    ")\n",
+    "axes[1, 1].set_title('Amount Distribution')\n",
+    "axes[1, 1].set_xlabel('Amount (NT$)')\n",
+    "axes[1, 1].set_ylabel('Frequency')\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**解題重點**：\n",
+    "1. **先 filter 再畫圖**：`df[df['category']=='Electronics']` 是所有圖的共同起點，避免每張圖都重寫條件。\n",
+    "2. **subplot 存取**：`axes[row, col]` 拿到指定子圖；sns 函式用 `ax=` 指定繪製位置。\n",
+    "3. **Top N 排行**：`groupby().sum().sort_values(ascending=False).head(5)`，畫橫條圖（`x=amount, y=product_name`）商品名字比較好讀。\n",
+    "4. **避免 FutureWarning**：seaborn 新版要求 `palette` 搭配 `hue`；圖例重複就 `legend=False`。\n",
+    "5. **`plt.tight_layout()`** 在 `plt.show()` 前呼叫，自動把 suptitle、軸標籤排好。\n",
+    "\n",
+    "🎉 這份 Electronics 儀表板就是你可以直接放進履歷 side project 的成果。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 延伸：把儀表板存成 PNG\n",
+    "\n",
+    "面試作品集或週報時，加一行 `plt.savefig()` 就能把圖輸出成高解析檔案。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 範例：存成 150 dpi 的 PNG（取消註解即可執行）\n",
+    "# fig.savefig('electronics_dashboard.png', dpi=150, bbox_inches='tight')\n",
+    "# print('已輸出 electronics_dashboard.png')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- 新增 `S5_visualization_essentials_solution.ipynb`，對應 S5 課堂三段練習的完整解答
- 送分題：品類訂單數長條圖 + `sns.histplot` 金額直方圖
- 核心題：North vs South 月度營收雙線折線圖（`hue='region'`）、vip_level 客單價箱型圖
- 挑戰題：Electronics-only 2x2 迷你儀表板（月度趨勢 / 地區排名 / Top 5 商品 / 金額分布）
- 附教學提示：seaborn `palette`+`hue` FutureWarning 處理、`legend=False` 隱藏重複圖例、`plt.tight_layout()` 使用時機

## Test plan
- [x] `ast.parse` 全 code cells 通過
- [x] 路徑使用 `../datasets/ecommerce/orders_enriched.csv`，與 S5 一致
- [x] 維持 S5 樣式：`sns.set_theme(style='whitegrid')`、`axes.unicode_minus=False`
- [ ] 在 Jupyter 實跑確認四張圖正常輸出（需資料已由 S3 產生）

Generated with [Claude Code](https://claude.com/claude-code)