### PR TITLE
feat(course): notebook 靜態 smoke test 套件

### DIFF
--- a/Special-Edition_python_DA/Python_DA_Course/tests/README.md
+++ b/Special-Edition_python_DA/Python_DA_Course/tests/README.md
@@ -1,0 +1,46 @@
+# Notebook Smoke Tests
+
+靜態煙霧測試套件，驗證 6 個 session notebooks 的結構完整性，**無需安裝 numpy/pandas/jupyter**。
+
+## 覆蓋項目
+
+- **JSON 格式檢查** — 每個 `.ipynb` 可被 `json.load` 解析且包含 `cells`
+- **Python 語法檢查** — 所有 code cells 串接後可被 `ast.parse`（自動剔除 `%magic` / `!shell`）
+- **結構檢查** — 每個 notebook 至少含 1 個 markdown + 1 個 code cell
+- **資料集存在性** — `datasets/ecommerce/` 下的 `products.csv`、`orders_raw.csv`、`customers.csv`
+- **README 一致性** — 主 `README.md` 須提及 S1–S6 全部 session
+
+## 執行方式
+
+於 `Python_DA_Course/` 目錄下：
+
+```bash
+# 方式一：pytest（推薦）
+python -m pytest tests/ -v
+
+# 方式二：直接執行腳本
+python tests/test_notebooks_static.py
+
+# 僅收集測試（dry-run）
+python -m pytest --collect-only tests/
+```
+
+## 為何不使用 nbclient / nbformat？
+
+課程主機環境僅保證 **Python 3 stdlib + pytest**，未安裝 `nbformat`、`nbclient`、`numpy`、`pandas`。
+本測試套件刻意只使用 `json`、`ast`、`pathlib`，確保在任何乾淨環境都可跑。
+
+若需要完整執行 notebook（非靜態檢查），請另行建立 `test_notebooks_execute.py` 並安裝：
+
+```bash
+pip install nbclient nbformat pandas numpy matplotlib seaborn plotly
+```
+
+## 疑難排解
+
+| 症狀 | 解法 |
+| :--- | :--- |
+| `pytest not installed` | `pip install pytest` |
+| `Notebook not found` | 確認從 `Python_DA_Course/` 執行，且 worktree 完整 |
+| `Syntax error in ...` | 檢查 notebook code cell 是否有未加 `%`/`!` 前綴的 shell 指令 |
+| `Missing datasets` | 先執行 Unit 0 的資料生成腳本 |

--- a/Special-Edition_python_DA/Python_DA_Course/tests/test_notebooks_static.py
+++ b/Special-Edition_python_DA/Python_DA_Course/tests/test_notebooks_static.py
@@ -1,0 +1,97 @@
+"""Static smoke tests for Python_DA_Course notebooks.
+
+Stdlib-only: works without numpy/pandas/jupyter/nbformat installed.
+Run:
+    python -m pytest tests/
+    python tests/test_notebooks_static.py
+"""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+try:
+    import pytest
+except ImportError:  # pragma: no cover
+    pytest = None  # type: ignore
+
+COURSE_ROOT = Path(__file__).resolve().parent.parent
+DATASETS_DIR = COURSE_ROOT / "datasets" / "ecommerce"
+
+NOTEBOOKS = [
+    "M1_Numpy_Basic/S1_numpy_vectorization.ipynb",
+    "M2_Pandas_Basic/S2_pandas_io_cleaning.ipynb",
+    "M3_Pandas_Advanced/S3_pandas_transform.ipynb",
+    "M3_Pandas_Advanced/S4_timeseries_eda.ipynb",
+    "M4_Matplotlib_Seaborn_Basic/S5_visualization_essentials.ipynb",
+    "M6_Plotly_Projects/S6_plotly_capstone.ipynb",
+]
+
+
+def _load_notebook(rel_path: str) -> dict:
+    nb_path = COURSE_ROOT / rel_path
+    assert nb_path.exists(), f"Notebook not found: {nb_path}"
+    with nb_path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _concat_code_cells(nb: dict) -> str:
+    chunks = []
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        src = cell.get("source", "")
+        if isinstance(src, list):
+            src = "".join(src)
+        # Strip IPython magics / shell lines that break ast.parse
+        cleaned = "\n".join(
+            line for line in src.splitlines()
+            if not line.lstrip().startswith(("%", "!", "?"))
+        )
+        chunks.append(cleaned)
+    return "\n\n".join(chunks)
+
+
+if pytest is not None:
+
+    @pytest.mark.parametrize("rel_path", NOTEBOOKS)
+    def test_notebook_is_valid_json(rel_path: str) -> None:
+        nb = _load_notebook(rel_path)
+        assert "cells" in nb, f"{rel_path} missing 'cells' key"
+        assert isinstance(nb["cells"], list)
+
+    @pytest.mark.parametrize("rel_path", NOTEBOOKS)
+    def test_notebook_code_cells_parse(rel_path: str) -> None:
+        nb = _load_notebook(rel_path)
+        code = _concat_code_cells(nb)
+        try:
+            ast.parse(code)
+        except SyntaxError as exc:
+            raise AssertionError(f"Syntax error in {rel_path}: {exc}") from exc
+
+    @pytest.mark.parametrize("rel_path", NOTEBOOKS)
+    def test_notebook_has_expected_structure(rel_path: str) -> None:
+        nb = _load_notebook(rel_path)
+        types = [c.get("cell_type") for c in nb.get("cells", [])]
+        assert types.count("markdown") >= 1, f"{rel_path} has no markdown cell"
+        assert types.count("code") >= 1, f"{rel_path} has no code cell"
+
+    def test_datasets_exist() -> None:
+        required = ["products.csv", "orders_raw.csv", "customers.csv"]
+        missing = [name for name in required if not (DATASETS_DIR / name).exists()]
+        assert not missing, f"Missing datasets under {DATASETS_DIR}: {missing}"
+
+    def test_readme_mentions_all_sessions() -> None:
+        readme = COURSE_ROOT / "README.md"
+        assert readme.exists(), f"README.md not found at {readme}"
+        text = readme.read_text(encoding="utf-8")
+        missing = [f"S{i}" for i in range(1, 7) if f"S{i}" not in text]
+        assert not missing, f"README.md missing session markers: {missing}"
+
+
+if __name__ == "__main__":
+    if pytest is None:
+        print("pytest not installed — install via: pip install pytest")
+        raise SystemExit(1)
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
- 新增 Unit 7 notebook 煙霧測試套件於 `Special-Edition_python_DA/Python_DA_Course/tests/`
- 純 stdlib + pytest，無需 numpy/pandas/jupyter/nbformat
- 覆蓋 S1~S6 六個 session notebooks 的靜態結構驗證

## 測試項目
- `test_notebook_is_valid_json` — 參數化驗證 6 個 `.ipynb` 可被 `json.load` 解析
- `test_notebook_code_cells_parse` — 串接所有 code cells 後 `ast.parse`（自動剔除 magics/shell）
- `test_notebook_has_expected_structure` — 每個 notebook 至少 1 markdown + 1 code cell
- `test_datasets_exist` — 驗證 `datasets/ecommerce/` 下三個 CSV 存在
- `test_readme_mentions_all_sessions` — 主 README 須提及 S1–S6

## Test plan
- [x] `python3 -m py_compile` 通過
- [x] 97 LOC（< 150 LOC 上限）
- [ ] 在有 pytest 的環境執行 `python -m pytest tests/ -v`
- [ ] 在無 pytest 環境執行 `python tests/test_notebooks_static.py` 得到 fallback 提示

Generated with Claude Code