### PR TITLE
feat(course): 中文字型跨平台設定（matplotlib/plotly）

### DIFF
--- a/Special-Edition_python_DA/Python_DA_Course/common/font_setup.py
+++ b/Special-Edition_python_DA/Python_DA_Course/common/font_setup.py
@@ -1,0 +1,98 @@
+"""跨平台繁體中文字型設定輔助模組。
+
+本模組提供統一介面，自動偵測作業系統並為 matplotlib 與 plotly 設定
+可用的繁體中文字型，避免圖表出現「豆腐字」（□□□）。
+
+使用方式：
+    from common.font_setup import setup_chinese_font, set_plotly_chinese_font
+    setup_chinese_font()          # matplotlib / seaborn
+    set_plotly_chinese_font()     # plotly express / graph_objects
+"""
+from __future__ import annotations
+
+import platform
+from typing import Optional
+
+_FONT_CANDIDATES = {
+    "Darwin": ["PingFang TC", "Heiti TC", "Arial Unicode MS"],
+    "Windows": ["Microsoft JhengHei", "Microsoft YaHei", "SimHei"],
+    "Linux": ["Noto Sans CJK TC", "WenQuanYi Zen Hei", "Source Han Sans TC"],
+}
+
+_INSTALL_HINT = {
+    "Darwin": "macOS 內建應已包含 PingFang TC，請確認系統字型未被移除。",
+    "Windows": "Windows 內建應已包含 Microsoft JhengHei，請檢查控制台字型設定。",
+    "Linux": "請執行：sudo apt install fonts-noto-cjk（Ubuntu/Debian）。",
+}
+
+
+def _available_cjk_fonts(candidates: list[str]) -> list[str]:
+    """回傳 matplotlib fontManager 中實際存在的候選字型。"""
+    from matplotlib import font_manager
+
+    installed = {f.name for f in font_manager.fontManager.ttflist}
+    return [name for name in candidates if name in installed]
+
+
+def setup_chinese_font() -> Optional[str]:
+    """偵測平台並設定 matplotlib 繁體中文字型。
+
+    Returns:
+        成功選用的字型名稱；若無任何候選字型可用則回傳 None 並印出安裝提示。
+    """
+    import matplotlib.pyplot as plt
+
+    system = platform.system()
+    candidates = _FONT_CANDIDATES.get(system, _FONT_CANDIDATES["Linux"])
+    available = _available_cjk_fonts(candidates)
+
+    if not available:
+        print(f"[font_setup] 找不到可用的繁體中文字型（平台：{system}）。")
+        print(f"[font_setup] 安裝建議：{_INSTALL_HINT.get(system, '請手動安裝 Noto Sans CJK TC。')}")
+        return None
+
+    chosen = available[0]
+    plt.rcParams["font.sans-serif"] = [chosen] + plt.rcParams.get("font.sans-serif", [])
+    plt.rcParams["axes.unicode_minus"] = False
+    print(f"[font_setup] 已套用 matplotlib 中文字型：{chosen}")
+    return chosen
+
+
+def set_plotly_chinese_font(font_name: Optional[str] = None) -> Optional[str]:
+    """設定 plotly 預設模板的中文字型。
+
+    Args:
+        font_name: 指定字型；若為 None 則依平台自動挑選。
+
+    Returns:
+        實際套用的字型名稱，或 None。
+    """
+    import plotly.io as pio
+
+    if font_name is None:
+        system = platform.system()
+        candidates = _FONT_CANDIDATES.get(system, _FONT_CANDIDATES["Linux"])
+        available = _available_cjk_fonts(candidates)
+        font_name = available[0] if available else None
+
+    if font_name is None:
+        print("[font_setup] plotly 未設定中文字型：找不到可用字型。")
+        return None
+
+    template_name = pio.templates.default or "plotly"
+    template = pio.templates[template_name]
+    template.layout.font.family = font_name
+    print(f"[font_setup] 已套用 plotly 中文字型：{font_name}（template={template_name}）")
+    return font_name
+
+
+if __name__ == "__main__":
+    from matplotlib import font_manager
+
+    print(f"偵測平台：{platform.system()}")
+    candidates = _FONT_CANDIDATES.get(platform.system(), [])
+    print(f"候選字型：{candidates}")
+    installed = {f.name for f in font_manager.fontManager.ttflist}
+    print(f"系統實際可用的候選字型：{[c for c in candidates if c in installed]}")
+    chosen = setup_chinese_font()
+    print(f"最終選用：{chosen}")

--- a/Special-Edition_python_DA/Python_DA_Course/docs/CHINESE_FONT_SETUP.md
+++ b/Special-Edition_python_DA/Python_DA_Course/docs/CHINESE_FONT_SETUP.md
@@ -1,0 +1,85 @@
+# 繁體中文字型設定指引
+
+> 適用於本課程 M4（matplotlib + seaborn）與 M6（plotly）所有筆記本。
+
+## 為什麼會出現「豆腐字」？
+
+matplotlib 與 plotly 預設使用的字型家族（DejaVu Sans、Open Sans 等）並未包含 CJK（中文、日文、韓文）字符，因此當圖表標題、軸標籤或圖例含有中文時，字形渲染器找不到對應的 glyph，就會以空心方塊 □□□（俗稱「豆腐字」）取代。解法是改用系統中已安裝、且包含 CJK 字符的字型。
+
+## 快速使用
+
+在任何筆記本或腳本最上方加入：
+
+```python
+from common.font_setup import setup_chinese_font, set_plotly_chinese_font
+
+setup_chinese_font()          # 供 matplotlib / seaborn 使用
+set_plotly_chinese_font()     # 供 plotly express / graph_objects 使用
+```
+
+輔助模組會自動依作業系統挑選下列順序的字型：
+
+| 平台 | 優先順序 |
+| :--- | :--- |
+| macOS | PingFang TC → Heiti TC → Arial Unicode MS |
+| Windows | Microsoft JhengHei → Microsoft YaHei → SimHei |
+| Linux | Noto Sans CJK TC → WenQuanYi Zen Hei → Source Han Sans TC |
+
+## 各平台手動安裝
+
+### macOS
+系統內建 **PingFang TC**，無需額外安裝。若遭移除，可從「字體册」重新啟用。
+
+### Windows
+系統內建 **微軟正黑體 (Microsoft JhengHei)**，無需額外安裝。
+
+### Linux（Ubuntu / Debian）
+```bash
+sudo apt update
+sudo apt install -y fonts-noto-cjk
+```
+安裝後請重新啟動 Python kernel，並清除 matplotlib 字型快取：
+```bash
+rm -rf ~/.cache/matplotlib
+```
+
+### Google Colab / 雲端環境
+```python
+!apt install -y fonts-noto-cjk
+!rm -rf ~/.cache/matplotlib
+```
+接著從選單選擇「執行階段 → 重新啟動執行階段」後重新執行 `setup_chinese_font()`。
+
+## 驗證片段
+
+執行以下程式碼，若標題正確顯示繁體中文即代表設定成功：
+
+```python
+import matplotlib.pyplot as plt
+from common.font_setup import setup_chinese_font
+
+setup_chinese_font()
+
+fig, ax = plt.subplots()
+ax.plot([1, 2, 3], [4, 5, 6])
+ax.set_title("中文字型測試：臺灣資料分析課程")
+ax.set_xlabel("時間（月）")
+ax.set_ylabel("數量")
+plt.show()
+```
+
+Plotly 驗證：
+
+```python
+import plotly.express as px
+from common.font_setup import set_plotly_chinese_font
+
+set_plotly_chinese_font()
+fig = px.bar(x=["一月", "二月", "三月"], y=[10, 20, 15], title="中文標題測試")
+fig.show()
+```
+
+## 疑難排解
+
+- 仍顯示豆腐字：刪除 `~/.cache/matplotlib` 後重啟 kernel。
+- 執行 `python common/font_setup.py` 可列出目前系統偵測到的候選字型，便於除錯。


### PR DESCRIPTION
## Summary
- 新增 `common/font_setup.py`：單一輔助模組，依 `platform.system()` 自動挑選 macOS/Windows/Linux 對應繁體中文字型，涵蓋 matplotlib 與 plotly。
- 新增 `docs/CHINESE_FONT_SETUP.md`：解釋豆腐字成因、各平台手動安裝指引、Colab 步驟與驗證片段。
- 解決 M4（matplotlib + seaborn）與 M6（plotly）筆記本在學生環境常見的中文字型問題。

## 設計重點
- `setup_chinese_font()` 使用 `matplotlib.font_manager.fontManager.ttflist` 檢查實際可用字型，避免盲設 rcParams。
- 設定 `axes.unicode_minus = False` 防止負號亂碼。
- `set_plotly_chinese_font()` 修改預設 template 的 layout.font.family，讓後續 `px` 圖表自動套用。
- 腳本 `__main__` 區塊提供診斷輸出。
- 98 LOC，符合 < 100 LOC 規範。

## Test plan
- [x] `python3 -m py_compile` 通過
- [x] AST parse 通過
- [x] 文件非空
- [ ] macOS 實機執行 `python common/font_setup.py` 確認輸出 PingFang TC
- [ ] Colab 上執行 `!apt install -y fonts-noto-cjk` 後驗證

🤖 Generated with [Claude Code](https://claude.com/claude-code)