### PR TITLE
feat(course): S6 Capstone 解答版 + 3 個延伸挑戰

### DIFF
--- a/Special-Edition_python_DA/Python_DA_Course/M6_Plotly_Projects/S6_plotly_capstone_solution.ipynb
+++ b/Special-Edition_python_DA/Python_DA_Course/M6_Plotly_Projects/S6_plotly_capstone_solution.ipynb
@@ -1,0 +1,606 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# S6 — Plotly 互動 + 完整 Capstone 案例【解答版】\n",
+    "\n",
+    "> **版本**：解答版（含 3 個延伸挑戰）  \n",
+    "> **時間**：2 小時（講授 60 + 實作 50 + 成果發表 10）  \n",
+    "> **資料**：`orders_raw.csv`（從頭走一遍完整 DE/DA 流程）  \n",
+    "> **學完能幹嘛**：獨立完成 raw CSV → 清理 → 分析 → 互動式儀表板的**全流程**，並且可以寫出 **可重用的儀表板產生函式**。\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## 解答版的三個重點\n",
+    "\n",
+    "本 notebook 在 S6 原版的基礎上額外提供：\n",
+    "\n",
+    "1. **延伸挑戰 1：時間篩選器** — 使用 `plotly.graph_objects` 的 `updatemenus` 在月度趨勢圖上加入「全年 / Q1 / Q2 / Q3 / Q4」切換按鈕。\n",
+    "2. **延伸挑戰 2：RFM 3D 散佈圖** — 用 `px.scatter_3d` 將顧客依 Recency / Frequency / Monetary 分群，色彩依 `vip_level` 區分。\n",
+    "3. **延伸挑戰 3：可重用 Pipeline** — 把「載入 → 清理 → 合併 → 儀表板 → 存 HTML」整個打包成 `generate_dashboard()` 函式，未來只要換 CSV 路徑就能跑出新報表。\n",
+    "\n",
+    "解答版同時會**把 S6 的教學提示補得更完整**，特別是 Plotly `subplots.make_subplots` 的 `specs` 參數、Plotly Express 在複雜排版時的限制、以及 HTML 成品該如何交付 / 部署。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Part A — Plotly Express 速成（30 min）\n",
+    "\n",
+    "先複習 6 個最常用的 Plotly Express 函式。這一段與 S6 完全相同，目的只是讓你在動手做 Capstone 前，手感先熱起來。\n",
+    "\n",
+    "> 💡 **教學提示**：Plotly Express（簡稱 `px`）是 Plotly 的「高階 API」，一行就能畫出一張互動圖；但真正做儀表板、多圖排版、加按鈕時，必須改用 `plotly.graph_objects`（`go`）這個「低階 API」。這兩者的關係類似 `sns.lineplot()` 對比 `matplotlib.pyplot`。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import plotly.express as px\n",
+    "import plotly.graph_objects as go\n",
+    "import plotly.io as pio\n",
+    "from plotly.subplots import make_subplots\n",
+    "\n",
+    "pio.templates.default = 'plotly_white'  # 乾淨白底\n",
+    "\n",
+    "df = pd.read_csv(\n",
+    "    '../datasets/ecommerce/orders_enriched.csv',\n",
+    "    parse_dates=['order_date'],\n",
+    ")\n",
+    "print('資料形狀:', df.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 1) 折線圖：月度營收\n",
+    "df['month'] = df['order_date'].dt.to_period('M').astype(str)\n",
+    "monthly = df.groupby('month', as_index=False)['amount'].sum()\n",
+    "\n",
+    "fig = px.line(monthly, x='month', y='amount', markers=True,\n",
+    "              title='Monthly Revenue Trend')\n",
+    "fig.update_layout(height=400)\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 2) 長條圖：地區營收\n",
+    "region_rev = df.groupby('region', as_index=False)['amount'].sum().sort_values('amount', ascending=False)\n",
+    "fig = px.bar(region_rev, x='region', y='amount', text='amount',\n",
+    "             color='region', title='Revenue by Region')\n",
+    "fig.update_traces(texttemplate='%{text:,.0f}', textposition='outside')\n",
+    "fig.update_layout(height=400, showlegend=False)\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 3) 散佈圖：單價 vs 金額\n",
+    "fig = px.scatter(df, x='unit_price', y='amount',\n",
+    "                 color='category', hover_data=['product_name', 'customer_name'],\n",
+    "                 title='Unit Price vs Order Amount')\n",
+    "fig.update_layout(height=450)\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 4) 箱型圖：品類分布\n",
+    "fig = px.box(df, x='category', y='amount', color='category',\n",
+    "             title='Order Amount by Category')\n",
+    "fig.update_layout(height=400, showlegend=False)\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 5) 直方圖：金額分布\n",
+    "fig = px.histogram(df, x='amount', nbins=30, title='Amount Distribution')\n",
+    "fig.update_layout(height=400)\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 6) 圓餅圖：VIP 等級佔比\n",
+    "vip_rev = df.groupby('vip_level', as_index=False)['amount'].sum()\n",
+    "fig = px.pie(vip_rev, names='vip_level', values='amount',\n",
+    "             title='VIP Level Share', hole=0.4)\n",
+    "fig.update_layout(height=400)\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Part B — Capstone：從 raw 到 dashboard 完整走一遍（50 min）\n",
+    "\n",
+    "**情境**：你是公司新進 DA，主管丟給你一份髒的訂單 CSV，下週一要交一份互動式儀表板。  \n",
+    "**目標**：完整走一次 S2（清理）→ S3（合併）→ S4（時序/聚合）→ S6（視覺化）。\n",
+    "\n",
+    "> 💡 **教學提示（解答版額外補充）**：真實世界裡，DA 的工作 70% 都在「清理 + 合併」，真正做圖往往只佔 20%。所以請把 Step 1–3 當作重點，Step 4 只是「最後 1 公里」。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Step 1 — 載入與清理（S2）\n",
+    "\n",
+    "把清理邏輯包成函式 `load_and_clean_orders()`，之後延伸挑戰 3 會直接重用這個函式。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_and_clean_orders(path):\n",
+    "    \"\"\"封裝 S2 的清理邏輯，方便未來重用。\n",
+    "\n",
+    "    步驟：欄名標準化 → 金額轉 float → 日期轉 datetime → 缺值處理 → 去重。\n",
+    "    \"\"\"\n",
+    "    df = pd.read_csv(path)\n",
+    "    df.columns = df.columns.str.strip().str.lower()\n",
+    "    df['amount'] = (\n",
+    "        df['amount'].astype(str)\n",
+    "        .str.replace('$', '', regex=False)\n",
+    "        .str.replace(',', '', regex=False)\n",
+    "        .astype(float)\n",
+    "    )\n",
+    "    df['order_date'] = pd.to_datetime(df['order_date'], errors='coerce')\n",
+    "    df = df.dropna(subset=['order_date'])\n",
+    "    df['qty'] = df['qty'].fillna(df['qty'].median())\n",
+    "    df = df.drop_duplicates()\n",
+    "    return df\n",
+    "\n",
+    "orders = load_and_clean_orders('../datasets/ecommerce/orders_raw.csv')\n",
+    "print(f'清理完成：{orders.shape[0]} 筆訂單')\n",
+    "orders.head(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Step 2 — 合併主檔（S3）"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "customers = pd.read_csv('../datasets/ecommerce/customers.csv')\n",
+    "products  = pd.read_csv('../datasets/ecommerce/products.csv')\n",
+    "\n",
+    "enriched = (\n",
+    "    orders\n",
+    "    .merge(customers, on='customer_id', how='left')\n",
+    "    .merge(products,  on='product_id',  how='left')\n",
+    ")\n",
+    "print(f'合併後形狀: {enriched.shape}')\n",
+    "print(f'欄位數: {len(enriched.columns)}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Step 3 — 計算關鍵指標（S3 + S4）"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "enriched['month'] = enriched['order_date'].dt.to_period('M').astype(str)\n",
+    "\n",
+    "kpis = {\n",
+    "    '總營收':     enriched['amount'].sum(),\n",
+    "    '總訂單數':   len(enriched),\n",
+    "    '活躍顧客數': enriched['customer_id'].nunique(),\n",
+    "    '客單價':     enriched['amount'].sum() / len(enriched),\n",
+    "}\n",
+    "for k, v in kpis.items():\n",
+    "    print(f'{k}: {v:>12,.0f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Step 4 — 互動式儀表板（4 張圖，2x2 subplot）\n",
+    "\n",
+    "> 💡 **教學提示：`make_subplots` 的 `specs` 是什麼？**  \n",
+    "> Plotly 將「圖的座標系統」分成兩大類：  \n",
+    "> - `'xy'`：有 X/Y 軸的圖（折線、長條、散佈、箱型、直方）。  \n",
+    "> - `'domain'`：沒有 X/Y 軸，而是佔一塊區域（圓餅、甜甜圈、sunburst、treemap）。  \n",
+    "> \n",
+    "> 所以當你想在同一張 figure 放入「3 張 xy 圖 + 1 張圓餅」時，**必須用 `specs` 告訴 Plotly 每一格的類型**，不然它預設每一格都是 `xy`，圓餅圖會畫不出來。  \n",
+    "> \n",
+    "> **為什麼不直接用 Plotly Express？**  \n",
+    "> `px` 非常方便，但它**不支援在同一張 figure 中混合 xy 與 domain 類型**。一旦你的儀表板要做「折線 + 圓餅 + 長條」這種異質排版，就必須退回 `go + make_subplots` 這條路。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 先算四份資料\n",
+    "monthly     = enriched.groupby('month', as_index=False)['amount'].sum()\n",
+    "top_prod    = (enriched.groupby('product_name', as_index=False)['amount']\n",
+    "               .sum().sort_values('amount', ascending=False).head(10))\n",
+    "region_rev  = enriched.groupby('region', as_index=False)['amount'].sum()\n",
+    "cat_rev     = enriched.groupby('category', as_index=False)['amount'].sum()\n",
+    "\n",
+    "fig = make_subplots(\n",
+    "    rows=2, cols=2,\n",
+    "    subplot_titles=('Monthly Revenue Trend',\n",
+    "                    'Top 10 Products',\n",
+    "                    'Revenue by Region',\n",
+    "                    'Category Share'),\n",
+    "    specs=[[{'type': 'xy'},     {'type': 'xy'}],\n",
+    "           [{'type': 'xy'},     {'type': 'domain'}]],\n",
+    ")\n",
+    "\n",
+    "fig.add_trace(go.Scatter(x=monthly['month'], y=monthly['amount'],\n",
+    "                         mode='lines+markers', name='Monthly'), row=1, col=1)\n",
+    "fig.add_trace(go.Bar(x=top_prod['product_name'], y=top_prod['amount'],\n",
+    "                     name='Top Products'), row=1, col=2)\n",
+    "fig.add_trace(go.Bar(x=region_rev['region'], y=region_rev['amount'],\n",
+    "                     name='Region'), row=2, col=1)\n",
+    "fig.add_trace(go.Pie(labels=cat_rev['category'], values=cat_rev['amount'],\n",
+    "                     name='Category', hole=0.4), row=2, col=2)\n",
+    "\n",
+    "fig.update_layout(\n",
+    "    title_text='<b>E-Commerce Sales Dashboard — 2025【解答版】</b>',\n",
+    "    height=750, showlegend=False,\n",
+    ")\n",
+    "fig.update_xaxes(tickangle=45, row=1, col=2)\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Step 5 — 存檔：把儀表板變成可以寄出去的 HTML\n",
+    "\n",
+    "> 💡 **教學提示：HTML 成品怎麼交付 / 部署？**  \n",
+    "> `fig.write_html()` 產生的是一份**完全獨立的 HTML 檔案**（預設會把 plotly.js 以 CDN 方式載入），你可以：  \n",
+    "> 1. **直接寄 email** — 老闆點兩下就能在瀏覽器中互動。  \n",
+    "> 2. **丟 S3 / GCS / Azure Blob** — 配合 static website hosting，產生一個公開網址。  \n",
+    "> 3. **塞到公司內部 Confluence / Notion** — 多數知識庫都支援嵌入 HTML iframe。  \n",
+    "> 4. **升級為 Web App** — 當互動需求變複雜（需要後端計算、使用者登入），再轉用 **Streamlit**、**Dash** 或 **Gradio**。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig.write_html('../datasets/ecommerce/dashboard_solution.html')\n",
+    "print('✅ 儀表板已存成 dashboard_solution.html，可直接寄給老闆。')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 延伸挑戰 1 — 時間篩選器（`updatemenus`）\n",
+    "\n",
+    "讓使用者在月度趨勢圖上切換「全年 / Q1 / Q2 / Q3 / Q4」視角。\n",
+    "\n",
+    "> 💡 **觀念**：`updatemenus` 是 Plotly 的「按鈕 / 下拉選單」機制。每個按鈕本質上是一組 `args`，告訴 Plotly：「按下去之後，請把這些圖表屬性更新成這些值」。  \n",
+    "> 常見寫法有兩種：  \n",
+    "> - **切換 trace 顯示** — 用 `{'visible': [True, False, ...]}` 決定哪些 trace 要顯示。  \n",
+    "> - **切換資料本身** — 用 `{'x': [...], 'y': [...]}` 直接換掉 trace 的 x/y 數值（本節使用這種）。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 準備每一個季度的資料\n",
+    "enriched['quarter'] = enriched['order_date'].dt.quarter\n",
+    "\n",
+    "monthly_all = enriched.groupby('month', as_index=False)['amount'].sum()\n",
+    "\n",
+    "def monthly_by_quarter(q):\n",
+    "    sub = enriched[enriched['quarter'] == q]\n",
+    "    return sub.groupby('month', as_index=False)['amount'].sum()\n",
+    "\n",
+    "q_frames = {q: monthly_by_quarter(q) for q in [1, 2, 3, 4]}\n",
+    "\n",
+    "fig_q = go.Figure()\n",
+    "fig_q.add_trace(go.Scatter(\n",
+    "    x=monthly_all['month'], y=monthly_all['amount'],\n",
+    "    mode='lines+markers', name='Monthly Revenue',\n",
+    "    line=dict(width=3),\n",
+    "))\n",
+    "\n",
+    "def _btn(label, df_view):\n",
+    "    return dict(\n",
+    "        label=label,\n",
+    "        method='update',\n",
+    "        args=[{'x': [df_view['month'].tolist()],\n",
+    "               'y': [df_view['amount'].tolist()]},\n",
+    "              {'title': f'Monthly Revenue Trend — {label}'}],\n",
+    "    )\n",
+    "\n",
+    "buttons = [\n",
+    "    _btn('全年', monthly_all),\n",
+    "    _btn('Q1',   q_frames[1]),\n",
+    "    _btn('Q2',   q_frames[2]),\n",
+    "    _btn('Q3',   q_frames[3]),\n",
+    "    _btn('Q4',   q_frames[4]),\n",
+    "]\n",
+    "\n",
+    "fig_q.update_layout(\n",
+    "    title='Monthly Revenue Trend — 全年',\n",
+    "    height=450,\n",
+    "    updatemenus=[dict(\n",
+    "        type='buttons',\n",
+    "        direction='right',\n",
+    "        x=0.5, y=1.18, xanchor='center',\n",
+    "        showactive=True,\n",
+    "        buttons=buttons,\n",
+    "    )],\n",
+    ")\n",
+    "fig_q.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 延伸挑戰 2 — RFM 3D 散佈圖（`px.scatter_3d`）\n",
+    "\n",
+    "> 💡 **RFM 是什麼？** 顧客分群中最經典的 3 個指標：  \n",
+    "> - **Recency（R）**：上次購買距今幾天，越小越活躍。  \n",
+    "> - **Frequency（F）**：購買次數，越大越忠誠。  \n",
+    "> - **Monetary（M）**：總消費金額，越大越有貢獻度。  \n",
+    "> \n",
+    "> 把每一位顧客畫成 3D 空間中的一個點，就能一眼看出「誰是 VIP、誰是流失風險」。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 用 enriched 算 RFM\n",
+    "snapshot_date = enriched['order_date'].max() + pd.Timedelta(days=1)\n",
+    "\n",
+    "rfm = (\n",
+    "    enriched\n",
+    "    .groupby(['customer_id', 'customer_name', 'vip_level'], as_index=False)\n",
+    "    .agg(\n",
+    "        recency=('order_date', lambda s: (snapshot_date - s.max()).days),\n",
+    "        frequency=('order_date', 'count'),\n",
+    "        monetary=('amount', 'sum'),\n",
+    "    )\n",
+    ")\n",
+    "print(f'顧客數: {len(rfm)}')\n",
+    "rfm.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig_rfm = px.scatter_3d(\n",
+    "    rfm,\n",
+    "    x='recency', y='frequency', z='monetary',\n",
+    "    color='vip_level',\n",
+    "    hover_data=['customer_name'],\n",
+    "    title='RFM 3D Segmentation by VIP Level',\n",
+    "    labels={'recency': 'Recency (days)',\n",
+    "            'frequency': 'Frequency',\n",
+    "            'monetary': 'Monetary ($)'},\n",
+    ")\n",
+    "fig_rfm.update_traces(marker=dict(size=5, opacity=0.75))\n",
+    "fig_rfm.update_layout(height=600)\n",
+    "fig_rfm.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 延伸挑戰 3 — 可重用 Pipeline：`generate_dashboard()`\n",
+    "\n",
+    "把整條 pipeline 打包成一個函式：\n",
+    "\n",
+    "```python\n",
+    "generate_dashboard(\n",
+    "    orders_path='../datasets/ecommerce/orders_raw.csv',\n",
+    "    customers_path='../datasets/ecommerce/customers.csv',\n",
+    "    products_path='../datasets/ecommerce/products.csv',\n",
+    "    output_html='../datasets/ecommerce/dashboard_solution.html',\n",
+    ")\n",
+    "```\n",
+    "\n",
+    "之後每個月只要換 CSV 路徑，就能一鍵產出新的 HTML 儀表板 — 這就是「資料產品化」的雛形。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def generate_dashboard(orders_path, customers_path, products_path, output_html):\n",
+    "    \"\"\"端到端 pipeline：載入 → 清理 → 合併 → 繪製 4 圖儀表板 → 輸出 HTML。\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    orders_path : str\n",
+    "        原始訂單 CSV 路徑。\n",
+    "    customers_path : str\n",
+    "        顧客主檔 CSV 路徑。\n",
+    "    products_path : str\n",
+    "        商品主檔 CSV 路徑。\n",
+    "    output_html : str\n",
+    "        輸出 HTML 檔案的路徑。\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    plotly.graph_objects.Figure\n",
+    "        產生的儀表板 Figure，方便呼叫端再做二次修改。\n",
+    "    \"\"\"\n",
+    "    # 1. 載入 + 清理\n",
+    "    orders_df = load_and_clean_orders(orders_path)\n",
+    "    customers_df = pd.read_csv(customers_path)\n",
+    "    products_df = pd.read_csv(products_path)\n",
+    "\n",
+    "    # 2. 合併\n",
+    "    data = (\n",
+    "        orders_df\n",
+    "        .merge(customers_df, on='customer_id', how='left')\n",
+    "        .merge(products_df,  on='product_id',  how='left')\n",
+    "    )\n",
+    "    data['month'] = data['order_date'].dt.to_period('M').astype(str)\n",
+    "\n",
+    "    # 3. 聚合四份資料\n",
+    "    monthly_df = data.groupby('month', as_index=False)['amount'].sum()\n",
+    "    top_prod_df = (data.groupby('product_name', as_index=False)['amount']\n",
+    "                   .sum().sort_values('amount', ascending=False).head(10))\n",
+    "    region_df = data.groupby('region', as_index=False)['amount'].sum()\n",
+    "    cat_df = data.groupby('category', as_index=False)['amount'].sum()\n",
+    "\n",
+    "    # 4. 組合 2x2 subplot\n",
+    "    dash = make_subplots(\n",
+    "        rows=2, cols=2,\n",
+    "        subplot_titles=('Monthly Revenue Trend',\n",
+    "                        'Top 10 Products',\n",
+    "                        'Revenue by Region',\n",
+    "                        'Category Share'),\n",
+    "        specs=[[{'type': 'xy'}, {'type': 'xy'}],\n",
+    "               [{'type': 'xy'}, {'type': 'domain'}]],\n",
+    "    )\n",
+    "    dash.add_trace(go.Scatter(x=monthly_df['month'], y=monthly_df['amount'],\n",
+    "                              mode='lines+markers', name='Monthly'),\n",
+    "                   row=1, col=1)\n",
+    "    dash.add_trace(go.Bar(x=top_prod_df['product_name'],\n",
+    "                          y=top_prod_df['amount'], name='Top'),\n",
+    "                   row=1, col=2)\n",
+    "    dash.add_trace(go.Bar(x=region_df['region'], y=region_df['amount'],\n",
+    "                          name='Region'), row=2, col=1)\n",
+    "    dash.add_trace(go.Pie(labels=cat_df['category'], values=cat_df['amount'],\n",
+    "                          hole=0.4, name='Category'), row=2, col=2)\n",
+    "    dash.update_layout(\n",
+    "        title_text='<b>E-Commerce Sales Dashboard【auto-generated】</b>',\n",
+    "        height=750, showlegend=False,\n",
+    "    )\n",
+    "    dash.update_xaxes(tickangle=45, row=1, col=2)\n",
+    "\n",
+    "    # 5. 輸出 HTML\n",
+    "    dash.write_html(output_html)\n",
+    "    print(f'✅ Dashboard 已輸出：{output_html}')\n",
+    "    return dash\n",
+    "\n",
+    "\n",
+    "# 範例呼叫（與前面 Step 4/5 效果相同，但只用一行）\n",
+    "_ = generate_dashboard(\n",
+    "    orders_path='../datasets/ecommerce/orders_raw.csv',\n",
+    "    customers_path='../datasets/ecommerce/customers.csv',\n",
+    "    products_path='../datasets/ecommerce/products.csv',\n",
+    "    output_html='../datasets/ecommerce/dashboard_solution.html',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 小結與速查表\n",
+    "\n",
+    "| 想畫什麼 | Plotly Express / graph_objects |\n",
+    "|---|---|\n",
+    "| 折線 | `px.line(df, x, y, markers=True)` |\n",
+    "| 長條 | `px.bar(df, x, y, color, text)` |\n",
+    "| 散佈 | `px.scatter(df, x, y, color, hover_data)` |\n",
+    "| 3D 散佈 | `px.scatter_3d(df, x, y, z, color)` |\n",
+    "| 箱型 | `px.box(df, x, y, color)` |\n",
+    "| 直方 | `px.histogram(df, x, nbins)` |\n",
+    "| 圓餅 | `px.pie(df, names, values, hole=0.4)` |\n",
+    "| 多圖 | `make_subplots(specs=...) + add_trace` |\n",
+    "| 按鈕切換 | `fig.update_layout(updatemenus=[...])` |\n",
+    "| 存檔 | `fig.write_html(path)` |\n",
+    "\n",
+    "### 解答版三個延伸挑戰的學習重點\n",
+    "\n",
+    "1. **`updatemenus`**：了解 Plotly 的按鈕更新機制，能把一張「靜態」趨勢圖升級為「可切換視角」的互動圖。\n",
+    "2. **`px.scatter_3d` + RFM**：把顧客分群與 3D 視覺化結合，展示 Plotly 在多維資料上的優勢。\n",
+    "3. **`generate_dashboard()`**：從「在 notebook 中寫分析」進化到「把分析包成函式」，是從 DA 走向 Data Product 的關鍵一步。\n",
+    "\n",
+    "**記住一件事：DA/DE 的價值不在技術，在於你能回答老闆『所以呢？』這個問題。**"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- 新增 `S6_plotly_capstone_solution.ipynb`（解答版），完整重跑 S6 的 raw CSV → 儀表板 pipeline，並補上更詳細的教學提示
- 三個延伸挑戰：`updatemenus` 時間篩選器、`px.scatter_3d` RFM 分群、`generate_dashboard()` 可重用 pipeline 函式
- 解答版儀表板輸出到 `dashboard_solution.html`，避免覆蓋 S6 原版的 `dashboard.html`

## Key additions vs S6
- `make_subplots` 的 `specs` 參數教學（xy vs domain）
- Plotly Express 在異質排版上的限制說明
- HTML 成品的交付 / 部署方式（email、cloud storage、Streamlit/Dash 升級路徑）
- RFM 計算與 3D 視覺化
- 端到端 pipeline 打包為函式，是從 DA 走向 Data Product 的示範

## Test plan
- [x] `ast.parse` 驗證整本 notebook 的 code cells 語法正確
- [ ] 人工在 Jupyter 開啟並 run all（需要 datasets/ecommerce/）
- [ ] 檢查輸出的 `dashboard_solution.html` 是否與 S6 的 dashboard.html 並存

🤖 Generated with [Claude Code](https://claude.com/claude-code)