### PR TITLE
feat(course): 講師講稿 S1~S3（時間切分+關鍵教學點）

### DIFF
--- a/Special-Edition_python_DA/Python_DA_Course/teacher_notes/S1_teacher_notes.md
+++ b/Special-Edition_python_DA/Python_DA_Course/teacher_notes/S1_teacher_notes.md
@@ -1,0 +1,78 @@
+# S1 — NumPy 與向量化思維｜講師講稿
+
+> **課程時長**：2 小時（講授 70 min + 課堂練習 40 min + QA 10 min）
+> **對應 Notebook**：`M1_Numpy_Basic/S1_numpy_vectorization.ipynb`
+
+---
+
+## 1. 本節目標 (Learning Objectives)
+
+完成本節後，學員應能：
+
+1. 使用 `np.array()` 建立 1D/2D ndarray，並說明 `.shape`、`.dtype`、`.ndim` 的意義。
+2. 運用切片、布林遮罩（boolean mask）與 fancy indexing 篩選陣列資料。
+3. 解釋「向量化 (vectorization)」為何比 Python `for-loop` 快 10~100 倍，並實際量測證明。
+4. 運用 broadcasting 對不同形狀的陣列進行逐元素運算。
+5. 在電商商品資料集上，用 1~2 行 NumPy 回答「總庫存價值」「低庫存商品數」等商業問題。
+
+---
+
+## 2. 時間切分表
+
+```
+00:00-00:05  開場暖身：上節回顧（Python 基礎）＋ 為什麼資料分析要學 NumPy
+00:05-00:20  核心觀念 1/3：ndarray 基本概念 + shape/dtype demo
+00:20-00:40  核心觀念 2/3：索引、切片、布林遮罩（重點：& | 與括號）
+00:40-01:00  核心觀念 3/3：向量化運算、broadcasting、效能比較 live demo
+01:00-01:10  實務 Case：電商庫存分析（3 個商業問題各 1 行解決）
+01:10-01:50  課堂練習（40 min）：🟡 核心題 + 🔴 雙 11 折扣挑戰題
+01:50-02:00  QA + 下節預告（S2 Pandas I/O 與清理）
+```
+
+---
+
+## 3. 關鍵教學點 (Key Teaching Points)
+
+1. **向量化的「感覺」比語法重要**：學員常能背出 `np.array()`，但遇到迴圈題目時仍會寫 `for`。務必在第 3 段用 `time.time()` 實測對比 100 萬筆加總，讓學員「親眼看到」快 50 倍以上。
+2. **布林遮罩的括號陷阱**：`a[(a>10) & (a<20)]` 括號不可省，`and` / `or` 在 NumPy 裡會報 `ValueError`。這是本節最常見 bug，講到這裡請停下來寫錯誤版讓學員看 traceback。
+3. **dtype 決定一切**：`np.array([1, 2, 3])` 是 int64，但 `/` 後會變 float64；`int8` 溢位時不會報錯而是回繞（wrap-around）。這點若不強調，後面 Pandas 章節也會踩到。
+4. **Broadcasting 規則**：從右邊對齊、維度為 1 可擴展。畫一張 shape 對齊圖會比講 10 分鐘有用。
+5. **NumPy 的心智模型**：把 ndarray 想成「一塊連續記憶體 + 一層 view」，切片是 view 不是 copy，修改會互相影響——這個觀念在做特徵工程時很關鍵。
+
+---
+
+## 4. 學員常犯錯誤 (Common Pitfalls)
+
+- **用 Python list 寫 for-loop 處理大量數字**：`total = 0; for x in data: total += x*2`——應該改成 `(data*2).sum()`。
+- **混用 `and` 與 `&`**：`a[a>0 and a<10]` 會直接爆炸；正確是 `a[(a>0) & (a<10)]`。
+- **以為切片是 copy**：`b = a[:3]; b[0] = 99` 會改到 `a`，要用 `.copy()`。
+- **shape 搞錯**：`(3,)` 與 `(3,1)` 在 broadcasting 結果完全不同。
+- **用 `==` 比較浮點數**：應改用 `np.isclose()`。
+
+---
+
+## 5. 提問設計 (Discussion Prompts)
+
+1. 如果現在手上有 1000 萬筆感測器讀數要計算移動平均，你會用 Python list 還是 NumPy？為什麼？預期效能差多少？
+2. 為什麼 NumPy 要求 ndarray 裡元素型別一致（homogeneous），這個限制帶來什麼好處？
+3. 布林遮罩和 SQL 的 `WHERE` 子句有什麼異同？哪一個比較彈性？
+
+---
+
+## 6. 延伸資源 (Further Reading)
+
+- NumPy 官方 User Guide「Absolute Basics for Beginners」與「Broadcasting」章節（可在 numpy.org 搜尋）。
+- Jake VanderPlas《Python Data Science Handbook》第 2 章 NumPy（線上免費版可搜尋章節標題）。
+
+---
+
+## 7. 常見 Q&A
+
+**Q1：NumPy 跟 Pandas 有什麼差別？要全部學嗎？**
+A：NumPy 處理「同質型數值陣列」，Pandas 在 NumPy 上加了「欄名 + 索引 + 異質型別」。做資料分析兩個都要會，但 Pandas 底層就是 NumPy，所以 S1 是地基。
+
+**Q2：向量化是不是只要加個 `np.` 就好？**
+A：不是。關鍵是「用陣列運算取代 Python 層的迴圈」。如果你在 `for` 裡面呼叫 `np.sum()`，還是慢。要想辦法讓整個運算一次送進 NumPy。
+
+**Q3：`np.array` 和 `np.asarray` 差在哪？**
+A：`np.array` 預設會 copy，`np.asarray` 若輸入已是 ndarray 則不 copy。效能敏感時用 `asarray`。

--- a/Special-Edition_python_DA/Python_DA_Course/teacher_notes/S2_teacher_notes.md
+++ b/Special-Edition_python_DA/Python_DA_Course/teacher_notes/S2_teacher_notes.md
@@ -1,0 +1,79 @@
+# S2 — Pandas I/O 與資料清理｜講師講稿
+
+> **課程時長**：2 小時（講授 70 min + 課堂練習 40 min + QA 10 min）
+> **對應 Notebook**：`M2_Pandas_Basic/S2_pandas_io_cleaning.ipynb`
+
+---
+
+## 1. 本節目標 (Learning Objectives)
+
+完成本節後，學員應能：
+
+1. 區分 `DataFrame` 與 `Series`，並說明「索引 (index)」在 Pandas 中扮演的角色。
+2. 使用 `read_csv` / `read_excel` 讀檔，並用「五件事探索法」（`shape` / `head` / `info` / `describe` / `isna().sum()`）快速盤點資料狀況。
+3. 正確使用 `loc` 與 `iloc` 進行列／欄選取，理解「標籤 vs 位置」差異。
+4. 執行資料清理四大手法：欄名標準化、型別轉換、缺值處理、重複列移除。
+5. 把真實髒檔 `orders_raw.csv` 清成可分析的乾淨 DataFrame，並輸出 `orders_clean.csv` 完成一次微型 ETL。
+
+---
+
+## 2. 時間切分表
+
+```
+00:00-00:05  開場暖身：上節 NumPy 回顧 + 「資料科學家 80% 時間在清資料」的現實
+00:05-00:20  核心觀念 1/4：DataFrame / Series / Index 三件套
+00:20-00:35  核心觀念 2/4：read_csv 常用參數（encoding, sep, dtype, parse_dates）
+00:35-00:50  核心觀念 3/4：loc vs iloc（最易混淆，務必 demo 清楚）
+00:50-01:10  核心觀念 4/4：清理四大手法 + orders_raw 實務 Case 走一次 Step 1~7
+01:10-01:50  課堂練習（40 min）：🟡 核心清理題 + 🔴 封裝 clean_orders() 函式挑戰題
+01:50-02:00  QA + 下節預告（S3 groupby / merge / pivot）
+```
+
+---
+
+## 3. 關鍵教學點 (Key Teaching Points)
+
+1. **拿到新檔案的 SOP**：永遠先跑 `df.shape → df.head() → df.info() → df.describe() → df.isna().sum()` 這五行。這是 senior 和 junior 的差別。
+2. **`errors='coerce'` 的哲學**：`pd.to_datetime(x, errors='coerce')` 與 `pd.to_numeric(x, errors='coerce')` 會把不合法值轉成 `NaT` / `NaN` 而不是爆掉。這是處理髒資料的救命符，但也意味著「失敗會悄悄發生」——清完務必檢查缺值數。
+3. **`loc` vs `iloc`**：`loc` 是標籤 (label-based)、`iloc` 是位置 (integer-based)。`df.loc[0]` 在 index 被重設後會是不同的列。務必用 `df.set_index('id')` 後的情境展示差異。
+4. **欄名標準化是「免費」的投資**：`df.columns.str.strip().str.lower().str.replace(' ', '_')` 三行下去，後面所有程式碼都不會因為 `Customer ID` vs `customer_id` 而崩潰。
+5. **缺值處理沒有標準答案**：要依欄位意義決定——訂單日期缺失無法做時序分析，直接丟；金額缺失可用中位數補；類別缺失可補 `'Unknown'`。不要無腦 `dropna()` 或 `fillna(0)`。
+
+---
+
+## 4. 學員常犯錯誤 (Common Pitfalls)
+
+- **忘了 `errors='coerce'`**：`pd.to_datetime(df['date'])` 遇到一筆 `'2023/13/45'` 就整批 raise，導致以為清完但什麼都沒動。
+- **字串金額直接 astype(float)**：`'$1,355'` 會爆炸；要先 `.str.replace('$','').str.replace(',','')`。
+- **`loc` 寫成 `iloc`**：`df.iloc[df['age']>18]` 會 raise（布林條件要用 `loc`）。
+- **inplace=True 的濫用**：`df.drop(..., inplace=True)` 在新版 Pandas 已不建議，且常讓人搞不清楚變數狀態；改用賦值寫法。
+- **`df.append()`**：已 deprecated，請用 `pd.concat()`。
+- **讀 CSV 不指定 encoding**：Windows 中文檔常需 `encoding='utf-8-sig'` 或 `'big5'`。
+
+---
+
+## 5. 提問設計 (Discussion Prompts)
+
+1. 如果一份 100 萬筆的訂單檔，有 5% 訂單缺 `amount`、3% 缺 `order_date`、1% 缺 `customer_id`，你會如何決定各欄位的處理策略？依據是什麼？
+2. `loc` 和 `iloc` 看起來很像，為什麼 Pandas 要故意設計兩個？只保留一個會有什麼問題？
+3. 清完的資料要不要覆蓋原始檔？還是另存新檔？在團隊協作時哪種做法比較安全？
+
+---
+
+## 6. 延伸資源 (Further Reading)
+
+- Pandas 官方 User Guide「IO tools (text, CSV, HDF5, …)」與「Working with missing data」章節（可在 pandas.pydata.org 搜尋）。
+- 查詢 Pandas 官方 Cookbook 的 Data Cleaning 範例。
+
+---
+
+## 7. 常見 Q&A
+
+**Q1：`dropna()` 和 `fillna()` 哪個比較好？**
+A：沒有絕對答案，要看「缺值原因」。如果缺值是隨機的小比例（< 5%），`dropna` 省事；如果是系統性缺失或資料稀缺，`fillna` 配合領域知識（中位數、前值、分群平均）更好。
+
+**Q2：`pd.read_csv` 讀超大檔案記憶體爆掉怎辦？**
+A：用 `chunksize=100000` 分批讀、`usecols=[...]` 只讀需要的欄、`dtype={...}` 指定型別（字串欄改 `category` 可省很多記憶體）。
+
+**Q3：清理完該存 CSV 還是 Parquet？**
+A：給其他人看用 CSV、自己跑分析用 Parquet（檔案小 5~10 倍、讀取快、保留 dtype）。本課為了簡單都用 CSV。

--- a/Special-Edition_python_DA/Python_DA_Course/teacher_notes/S3_teacher_notes.md
+++ b/Special-Edition_python_DA/Python_DA_Course/teacher_notes/S3_teacher_notes.md
@@ -1,0 +1,82 @@
+# S3 — Pandas 轉換：groupby / merge / pivot｜講師講稿
+
+> **課程時長**：2 小時（講授 70 min + 課堂練習 40 min + QA 10 min）
+> **對應 Notebook**：`M3_Pandas_Advanced/S3_pandas_transform.ipynb`
+
+---
+
+## 1. 本節目標 (Learning Objectives)
+
+完成本節後，學員應能：
+
+1. 運用 `between`、`isin`、`&` / `|` 組合條件篩選 DataFrame。
+2. 使用 `groupby().agg()` 做單欄／多欄、單函式／多函式聚合，並說明它對應 SQL 的哪些子句。
+3. 使用 `merge()` 的 `on` 與 `how` 參數完成兩表、三表 join，並判斷應該使用 `left` / `inner` / `outer`。
+4. 使用 `pivot_table()` 建立「列 × 欄」的交叉分析矩陣，並說明與 `groupby` 的差異與等價性。
+5. 在電商三表資料（orders + customers + products）上，回答「各地區營收」「地區 Top3 商品」「VIP 貢獻佔比」等多維分析問題。
+
+---
+
+## 2. 時間切分表
+
+```
+00:00-00:05  開場暖身：上節 S2 回顧，確認大家都有 orders_clean.csv
+00:05-00:15  核心觀念 1/3：條件篩選補強（between / isin / 多條件括號）
+00:15-00:40  核心觀念 2/3：groupby 三層（單欄聚合 → agg 多函式 → 多欄多函式）
+00:40-01:00  核心觀念 3/3：merge 兩表 / 三表 join + how 四種選擇的差別
+01:00-01:10  實務 Case：電商銷售洞察 Q1~Q3 + pivot_table bonus
+01:10-01:50  課堂練習（40 min）：🟡 品類營收 Top N + 🔴 RFM 粗估挑戰題
+01:50-02:00  QA + 下節預告（S4 時間序列 EDA）
+```
+
+---
+
+## 3. 關鍵教學點 (Key Teaching Points)
+
+1. **groupby 的心智模型 = Split → Apply → Combine**：先按 key 分組、再對每組套用函式、最後把結果拼回去。這個三步驟講清楚，所有 groupby 題都能秒解。
+2. **`agg` 的三種寫法要全部示範**：
+   - 單函式：`.agg('sum')` 或 `.sum()`
+   - 多函式：`.agg(['count', 'sum', 'mean'])`
+   - 具名聚合：`.agg(total=('amount','sum'), cnt=('amount','count'))`（最推薦，結果欄名乾淨）
+3. **`merge` 的 `how` 四選一要畫 Venn 圖**：`inner`（交集）、`left`（保留左表全部）、`right`、`outer`（聯集）。90% 情境用 `left`，因為你通常是「從主表的角度去補資訊」。
+4. **`on` 欄名不一致時**：用 `left_on='uid', right_on='customer_id'`。要提醒學員 merge 後常見 bug 是「筆數暴增」——這通常代表 right 表的 key 不唯一（1:N 或 N:N）。
+5. **`groupby` vs `pivot_table` 何時用哪個**：兩者可互換，但想要「行=A, 列=B, 值=metric」的交叉報表時用 `pivot_table` 最直觀；想要程式化後續處理時用 `groupby`。
+
+---
+
+## 4. 學員常犯錯誤 (Common Pitfalls)
+
+- **`merge` 的 `on` 寫錯**：兩表欄名不同卻都寫 `on='id'` → `KeyError`。要改成 `left_on` / `right_on`。
+- **merge 後筆數爆炸**：沒先檢查 right 表 key 是否唯一，1:N 變 N:M。merge 前先跑 `df_right['key'].duplicated().sum()`。
+- **`groupby` 後忘記 reset_index**：結果變成 MultiIndex，後續 `merge` 或畫圖會卡住。視情況補 `.reset_index()`。
+- **`SettingWithCopyWarning`**：`df[df.a>0]['b'] = 1` 這種鏈式賦值會噴警告且不一定生效，要改用 `df.loc[df.a>0, 'b'] = 1`。
+- **`pivot_table` 預設 `aggfunc='mean'`**：想算總和時忘了指定 `aggfunc='sum'` 會得到錯誤結果。
+- **多條件篩選少了括號**：`df[df.a>0 & df.b<10]`——`&` 優先級高於 `>`，會先算 `0 & df.b` 報錯；正確是 `df[(df.a>0) & (df.b<10)]`。
+
+---
+
+## 5. 提問設計 (Discussion Prompts)
+
+1. 同樣算「每個地區總營收」，可以用 `groupby('region').sum()`、`pivot_table(index='region', values='amount', aggfunc='sum')`，甚至 SQL。三者背後的運算是一樣的嗎？你會怎麼選？
+2. 為什麼大多數情境 `merge` 都用 `how='left'` 而不是 `inner`？`inner` 會造成什麼隱性資料損失？
+3. 如果 orders 有 100 萬筆、customers 有 1 萬筆，merge 之後應該是幾筆？如果變成 150 萬筆，代表發生了什麼事？
+
+---
+
+## 6. 延伸資源 (Further Reading)
+
+- Pandas 官方 User Guide「Group by: split-apply-combine」與「Merge, join, concatenate and compare」章節（可在 pandas.pydata.org 搜尋）。
+- 查詢 Pandas 官方 Comparison with SQL 頁面，對照 SQL 與 Pandas 寫法。
+
+---
+
+## 7. 常見 Q&A
+
+**Q1：`merge` 和 `join` 有什麼差別？**
+A：`df.join()` 是 `merge` 的簡化版，預設用 index 對齊、預設 `how='left'`。彈性上 `merge` 完勝，實務上 90% 用 `merge` 就好。
+
+**Q2：`groupby` 很慢怎麼辦？**
+A：先確認是不是真的慢（1000 萬筆以下通常沒事）。若資料大，可試：(1) 先 `astype('category')` 分組欄、(2) 改用 `polars` 或 `duckdb`、(3) 避免 `apply(lambda)`，改用內建 `agg`。
+
+**Q3：可以用 SQL 做完這些為什麼要學 Pandas？**
+A：Pandas 的優勢是「與 Python 生態整合」——清完資料直接丟 scikit-learn 訓練、丟 matplotlib 畫圖，不需要中間層。SQL 和 Pandas 是互補而非取代關係。


### PR DESCRIPTION
## Summary
- 新增 `Special-Edition_python_DA/Python_DA_Course/teacher_notes/` 目錄下三份講師講稿：S1 NumPy 向量化、S2 Pandas I/O 與清理、S3 Pandas 轉換 groupby/merge/pivot
- 每份講稿包含：本節目標、2 小時時間切分表（5~10 分鐘顆粒度）、關鍵教學點、學員常犯錯誤、提問設計、延伸資源、常見 Q&A
- 內容與 M1~M3 對應 notebook 實際章節對齊，未編造任何外部連結

## Test plan
- [x] 三份 markdown 檔皆已建立且非空
- [x] 每份皆包含「時間切分」與「關鍵教學點」段落（Grep 驗證）
- [ ] 講師試讀一次，確認時間切分符合 2 小時節奏
- [ ] 對照 notebook 驗證關鍵教學點與實際 demo 內容一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)