### PR TITLE
feat(course): 講師講稿 S4~S6（時間序列/視覺化/Capstone）

### DIFF
--- a/Special-Edition_python_DA/Python_DA_Course/teacher_notes/S4_teacher_notes.md
+++ b/Special-Edition_python_DA/Python_DA_Course/teacher_notes/S4_teacher_notes.md
@@ -1,0 +1,66 @@
+# S4 講師講稿 — 時間序列 + EDA 實戰
+
+> 對應 notebook：`M3_Pandas_Advanced/S4_timeseries_eda.ipynb`
+> 節次時長：120 分鐘（講授 70 + 練習 40 + 收斂 10）
+
+---
+
+## 1. 本節目標
+
+1. 讓學員理解「商業問題幾乎都有時間維度」，能用 `.dt` accessor 快速拆年月日。
+2. 掌握 `resample`（需 datetime index）與 `groupby + to_period` 兩條路徑的差別與適用場景。
+3. 會用 `rolling(window).mean()` 對雜訊資料做平滑並解讀趨勢。
+4. 熟練 EDA 三板斧：`describe`、`value_counts`、`corr`，並能口語化解讀相關係數。
+5. 能產出一張「月度經營報表」，把技術能力對應到真實 DA 工作產出。
+
+## 2. 時間切分表
+
+| 時間 | 內容 | 備註 |
+|---|---|---|
+| 0~10 | 上節回顧 + 情境引入（老闆四問） | 強調「時間維度」是所有 DA 問題的底層 |
+| 10~20 | 日期操作：`to_datetime`、`.dt.year/month/day_name/to_period` | 現場示範 Excel vs Pandas |
+| 20~35 | `resample` 三種粒度（D/W/ME），強調 index 必須是 datetime | 示範 sort_index 必要性 |
+| 35~45 | `rolling` 移動平均，平滑日資料雜訊 | 對比 window=3 與 window=7 |
+| 45~60 | EDA 三招：`describe` / `value_counts` / `corr` | 解讀相關係數的三段式口訣 |
+| 60~70 | 實務 Case：月度、星期幾、地區×品類熱點 | 產出 monthly_revenue.csv 給 S5/S6 接手 |
+| 70~110 | 課堂練習（送分/核心/挑戰三層） | 挑戰題 = 月度經營報表 |
+| 110~120 | 小結、速查表、S5 預告 | 強調「數字不會說話，圖會」 |
+
+## 3. 關鍵教學點
+
+- **`resample` vs `groupby + to_period`**：`resample` 只能用在 datetime index 且支援填補空缺日期（頻率型），適合時序；`groupby('year_mon')` 則是把期間當作類別鍵，缺月份不會自動補 0。教學時兩種都示範，讓學員理解報表類用後者、趨勢圖類用前者。
+- **`'M'` vs `'ME'`**：pandas 2.2+ 後 `'M'` 被 deprecation 警告，改用 `'ME'`（Month End）、`'QE'`、`'YE'`。務必當場秀出警告訊息。
+- **`rolling` 的 window 意義**：N=7 代表包含當日往前數 7 天，前 N-1 列為 NaN，這是學員常問的點。
+- **相關係數解讀**：用「>0.7 強 / 0.3~0.7 中 / <0.3 弱」三段式，不要讓學員只看數字不說結論。
+
+## 4. 學員常犯錯誤
+
+1. **忘了 `sort_index()`**：`resample` 或 `rolling` 在未排序的 index 上會得到錯誤結果，要求所有人先 `set_index('order_date').sort_index()`。
+2. **`parse_dates` 漏掉**：`pd.read_csv` 沒帶 `parse_dates=['order_date']` 直接用 `.dt` 會噴 `AttributeError: Can only use .dt accessor with datetimelike values`。
+3. **`resample` 誤用在沒有 datetime index 的 DataFrame**：錯誤訊息 `TypeError: Only valid with DatetimeIndex`。
+4. **星期排序混亂**：`groupby('weekday')` 後直接畫圖會變成字母序（Friday 排在最前），要 `.reindex(week_order)`。
+5. **`to_period('M')` 的型別陷阱**：`Period` 物件在寫入 CSV 或 merge 時常出狀況，若要視覺化記得 `.astype(str)`。
+
+## 5. 提問設計
+
+1. 「如果我想知道『每週一的平均銷售』，該用 `resample` 還是 `groupby`？為什麼？」
+2. 「相關係數 0.65 算強還是中？你會怎麼對老闆描述這個關係？」
+3. 「為什麼挑戰題的月度報表裡，第一個月的成長率會是 NaN？這個 NaN 要不要補 0？」
+
+## 6. 延伸資源
+
+- pandas 官方文件：Time series / date functionality 章節（搜尋 "pandas timeseries user guide"）。
+- 書籍：《Python for Data Analysis》3rd ed.（Wes McKinney）第 11 章 Time Series。
+
+## 7. 常見 Q&A
+
+- **Q：`resample('M')` 和 `resample('ME')` 到底差在哪？**
+  A：結果相同，但 `'M'` 從 pandas 2.2 起會警告並在未來版本移除，請直接用 `'ME'`。
+- **Q：`rolling(7).mean()` 前 6 列是 NaN，要怎麼處理？**
+  A：畫圖時可以 `.dropna()`；若要保留長度可加 `min_periods=1`，但要提醒學員這會讓前幾個值失真。
+- **Q：`corr()` 只算數值欄，類別欄要怎麼看相關？**
+  A：本節不深入，可先提「類別看 `crosstab` 或卡方檢定」，留給進階課。
+
+## 8. 收斂金句
+
+「S4 教你把時間變成一條軸、把 EDA 變成一種直覺。下一節 S5，我們把這些數字畫出來，才算真正完成一份 DA 作品。」

--- a/Special-Edition_python_DA/Python_DA_Course/teacher_notes/S5_teacher_notes.md
+++ b/Special-Edition_python_DA/Python_DA_Course/teacher_notes/S5_teacher_notes.md
@@ -1,0 +1,74 @@
+# S5 講師講稿 — 視覺化精華：5 種必懂圖
+
+> 對應 notebook：`M4_Matplotlib_Seaborn_Basic/S5_visualization_essentials.ipynb`
+> 節次時長：120 分鐘（講授 70 + 練習 40 + 收斂 10）
+
+---
+
+## 1. 本節目標
+
+1. 理解「5 種圖涵蓋 90% 的 DA 場景」的選圖思維：趨勢 / 比較 / 關聯 / 分布 / 矩陣。
+2. 能用 seaborn 一行畫出可交付的折線、長條、散佈、箱型、熱力圖。
+3. 學會 `plt.subplots` 把多張圖組成儀表板，輸出 Q4 Sales Dashboard 成品。
+4. 掌握 matplotlib 與 seaborn 的分工：seaborn 打底、matplotlib 微調。
+5. 能將 S4 算出的洞察（月度、地區、品類）完整視覺化並輸出簡報級畫面。
+
+## 2. 時間切分表
+
+| 時間 | 內容 | 備註 |
+|---|---|---|
+| 0~10 | 為什麼「數字不會說話、圖會」+ 5 圖選擇依據 | 先秀對比：表格 vs lineplot |
+| 10~20 | 環境設定、`sns.set_theme`、中文字型提醒 | 示範 `axes.unicode_minus=False` |
+| 20~30 | 圖 1 折線圖：月度趨勢 | 強調 `marker='o'` 可讀性 |
+| 30~40 | 圖 2 長條圖：排序 + 數字標註 | 示範 `sort_values` 與 `plt.text` |
+| 40~50 | 圖 3 散佈圖：`hue` 上色、legend 外移 | 帶到 alpha、s 參數 |
+| 50~60 | 圖 4 箱型圖：解讀中位數/四分位/離群 | 這是學員最不熟的圖 |
+| 60~70 | 圖 5 熱力圖：`annot=True`、`fmt=',.0f'` | 導入「矩陣型」視覺 |
+| 70~85 | 實務 Case：2x3 儀表板整合 | 用 `axes[i, j]` 定位 |
+| 85~115 | 課堂練習（含 Electronics 迷你儀表板） | 強調「能放進履歷」 |
+| 115~120 | 小結 + S6 預告（靜態 → 互動） | |
+
+## 3. 關鍵教學點
+
+- **選圖依據（務必背下來）**：
+  - 想看「隨時間變化」→ 折線圖
+  - 想看「誰比誰大」→ 長條圖（記得排序）
+  - 想看「兩個數值是否相關」→ 散佈圖
+  - 想看「單一數值的分布與離群值」→ 箱型/直方圖
+  - 想看「兩個類別交叉的數值」→ 熱力圖
+- **seaborn 0.13+ 的 palette 警告**：直接對 `barplot(x, y, palette=...)` 上色會出 `FutureWarning: Passing palette without assigning hue is deprecated`。正確寫法是 `hue='region', legend=False` 一併加上。
+- **`plt.subplots` 的 axes 索引**：`nrows=2, ncols=3` → `axes[0,1]`；務必提醒「只有一個 row 或 col 時 axes 是一維」。
+- **tight_layout vs constrained_layout**：多圖儀表板推 `tight_layout()`，若標籤撞到則改 `constrained_layout=True`。
+
+## 4. 學員常犯錯誤
+
+1. **seaborn 0.13+ 的 palette 警告**：`sns.barplot(..., palette='viridis')` 沒加 `hue` 會觸發警告。解法是 `hue='region', legend=False`。
+2. **中文字型亂碼**：沒裝字型就用中文 title，圖上出現方框。建議先把 title 寫英文，或引導學員設定 `plt.rcParams['font.sans-serif']`。
+3. **長條圖忘了排序**：直接 `groupby().sum()` 後畫圖，x 軸順序是按字母而非金額，老闆看不懂誰第一名。
+4. **`axes[0, 1]` 寫成 `axes[0][1]`**：兩者其實都可用，但不統一會造成 debug 困擾。
+5. **在 loop 裡忘了 `plt.figure()`**：上一張圖被蓋掉或疊在同一張畫布。
+6. **存檔後圖是空的**：`plt.show()` 在 `plt.savefig()` 之前執行會清空 figure，要求順序：`savefig → show`。
+
+## 5. 提問設計
+
+1. 「老闆要看『哪一個地區最強』，你會選長條圖還是圓餅圖？為什麼？」
+2. 「箱型圖上方那些零散的點代表什麼？你會把它們丟掉還是留下？」
+3. 「如果同一張儀表板要同時顯示趨勢與比較，你會怎麼排版這 6 張圖？」
+
+## 6. 延伸資源
+
+- Seaborn 官方 gallery（搜尋 "seaborn example gallery"），裡面的每一張圖都有對應程式碼。
+- 書籍：《Storytelling with Data》by Cole Nussbaumer Knaflic，談 DA 視覺化選圖與排版。
+
+## 7. 常見 Q&A
+
+- **Q：matplotlib 和 seaborn 到底該選哪個？**
+  A：先用 seaborn 一行搞定 90% 場景，需要極度客製（座標軸、雙 y 軸、annotation）才轉 matplotlib。
+- **Q：為什麼我的 `sns.heatmap` 數字跑出科學記號？**
+  A：用 `fmt=',.0f'` 指定整數千分位格式。
+- **Q：圖太擠、標籤重疊怎麼辦？**
+  A：`plt.xticks(rotation=45)` + `plt.tight_layout()`，或 figsize 拉大。
+
+## 8. 收斂金句
+
+「能把 5 張圖畫對，你就比 80% 的文組 Excel 使用者更專業。S6 我們再加一層『互動』，讓老闆能自己點、自己篩。」

--- a/Special-Edition_python_DA/Python_DA_Course/teacher_notes/S6_teacher_notes.md
+++ b/Special-Edition_python_DA/Python_DA_Course/teacher_notes/S6_teacher_notes.md
@@ -1,0 +1,90 @@
+# S6 講師講稿 — Plotly 互動 + 完整 Capstone 案例
+
+> 對應 notebook：`M6_Plotly_Projects/S6_plotly_capstone.ipynb`
+> 節次時長：120 分鐘（講授 60 + 實作 50 + 成果發表 10）
+
+---
+
+## 1. 本節目標
+
+1. 學會 Plotly Express 6 個常用函式：`px.line / px.bar / px.scatter / px.box / px.histogram / px.pie`。
+2. 理解「靜態圖（S5）vs 互動圖（S6）」的使用場景與交付差異（.png vs .html）。
+3. 會用 `make_subplots + add_trace` 組合 2x2 互動儀表板，包含 xy 與 domain 混合。
+4. 能從 `orders_raw.csv` 獨立走一遍 S2→S3→S4→S6 全流程，輸出 `dashboard.html`。
+5. 透過 3 分鐘成果發表，培養用一句話講清楚「發現、行動、價值」的溝通力。
+
+## 2. 時間切分表（60 + 50 + 10）
+
+| 時間 | 區段 | 內容 |
+|---|---|---|
+| 0~5 | 講授 | 為什麼這是 Capstone：把 S1~S5 串成一個產品 |
+| 5~10 | 講授 | Plotly 與 matplotlib/seaborn 的核心差異（互動、hover、HTML） |
+| 10~35 | 講授 | Part A：6 個 px 函式現場示範（line/bar/scatter/box/hist/pie） |
+| 35~50 | 講授 | Part B Step1~3：clean → merge → KPIs |
+| 50~60 | 講授 | Part B Step4~5：`make_subplots` 2x2 + `write_html` |
+| 60~110 | 實作 | 學員獨立跑完整流程，講師巡場答疑 |
+| 110~120 | 成果發表 | 每人 30 秒：發現、下一步、應用場景 |
+
+## 3. 關鍵教學點
+
+- **Plotly Express vs graph_objects**：px 是高階 API（一行畫一張），go 是底層可完全客製。`make_subplots` 必須搭 go。
+- **`specs` 的 domain vs xy**：`px.pie` 使用 domain 類型，放進 subplot 時 `specs` 要寫 `{'type':'domain'}`，其他圖是 `{'type':'xy'}`。這是本節最常出錯的點。
+- **`write_html` 的魔力**：輸出一個可寄出去的單一 HTML 檔，不需要對方裝 Python。強調這是 DA 的「成品交付」標準動作。
+- **Capstone 的精神**：不要開 S2/S3 的 notebook 抄，逼學員從頭寫一次 `load_and_clean_orders` 函式，驗證是否真的學會。
+
+## 4. 成果發表流程（10 min）
+
+1. **每人 30 秒、依座位順序**，不提問以節省時間。
+2. 三個必答問題：
+   - 今天儀表板**最關鍵的發現**是什麼？（1 個數字 + 1 個解讀）
+   - 再給你 1 小時，你會新增哪張圖？
+   - 這個流程在你未來工作會用在哪？
+3. 講師現場打分（見下方評分建議）。
+4. 最後 2 分鐘選 1~2 位示範作品，投影到大螢幕輪播。
+
+## 5. 成果發表評分建議（簡易版，與 GRADING_RUBRIC 呼應）
+
+| 面向 | 配分 | 評分重點 |
+|---|---|---|
+| 技術完成度 | 40% | 流程是否跑完 S2→S6，dashboard.html 能否開啟、4 張子圖都有資料 |
+| 洞察品質 | 30% | 是否指出至少 1 個具體數字結論（非「營收不錯」這種空話） |
+| 視覺呈現 | 20% | 排版、配色、subplot_titles、hover 是否有意義 |
+| 口語表達 | 10% | 30 秒內是否講清楚「發現 + 行動」 |
+
+- A (90+)：全部 4 面向達標，洞察有驚喜
+- B (75~89)：技術完成、洞察普通
+- C (60~74)：儀表板能跑但有明顯錯誤或缺圖
+- F (<60)：未完成或僅複製貼上
+
+## 6. 學員常犯錯誤
+
+1. **Plotly subplot 混 domain/xy 時 `specs` 寫錯**：`px.pie`/`go.Pie` 放進 subplot 一定要指定 `{'type':'domain'}`，否則會出 `ValueError: Trace type 'pie' is not compatible with subplot type 'xy'`。
+2. **`px` 圖直接 `add_trace` 到 subplot**：`px` 回傳的是 Figure 而不是 trace，正確做法是取出 `fig.data[0]` 或直接用 `go.Scatter`、`go.Bar`。
+3. **`write_html` 存檔後在瀏覽器打不開**：路徑相對於 notebook 目錄，請用絕對路徑或先 `os.path.abspath` 確認。
+4. **`load_and_clean_orders` 忘了 `errors='coerce'`**：遇到髒日期直接噴錯，讓學員體會「為什麼要 coerce」。
+5. **subplot 只有一張圖顯示**：忘了 `row`、`col` 參數或所有 trace 都指到 `row=1, col=1`。
+6. **hover_data 塞太多欄**：變成一坨資訊牆，建議挑 2~3 個最有商業意義的欄位。
+
+## 7. 提問設計
+
+1. 「S5 的 matplotlib 儀表板可以做成 HTML 嗎？如果老闆要一個『能自己點』的版本，你會怎麼給他？」
+2. 「為什麼 Capstone 不讓你直接 import S3 的 notebook，而是要重寫一次？」
+3. 「這份 dashboard.html 寄給非技術的行銷主管，你會在 email 裡附上哪 3 句話來引導他看？」
+
+## 8. 延伸資源
+
+- Plotly 官方 Python 文件的 Plotly Express 章節（搜尋 "plotly express python"）。
+- Plotly 官方的 subplots 與 mixed subplot types 教學頁（搜尋 "plotly python subplots"）。
+
+## 9. 常見 Q&A
+
+- **Q：Plotly 圖太慢，資料超過 10 萬筆怎麼辦？**
+  A：px 預設會把所有點塞進 HTML，資料量大請先 `.sample()` 或聚合後再畫，或改用 `plotly.graph_objects` + `scattergl`。
+- **Q：dashboard.html 可以放到公司內網嗎？**
+  A：可以，它是純靜態 HTML + JS，丟到任何 static hosting 都能開。
+- **Q：Capstone 做完還想更進階，下一步學什麼？**
+  A：Streamlit（把 notebook 變 Web App）、Dash（Plotly 官方框架）、或學 SQL 把資料源從 CSV 換成資料庫。
+
+## 10. 收斂金句
+
+「12 小時課程的終點不是『你會用 Plotly』，而是『你能獨立把一份髒 CSV 變成老闆願意轉寄的 dashboard』。這才是 DA 的商業價值。」


### PR DESCRIPTION
## Summary
- 新增 `Special-Edition_python_DA/Python_DA_Course/teacher_notes/` 目錄下三份講師講稿
- S4 時間序列 + EDA、S5 視覺化精華、S6 Plotly Capstone
- 每份包含：本節目標、時間切分表、關鍵教學點、常犯錯誤、提問設計、延伸資源、Q&A
- S6 另含成果發表流程與簡易評分建議（與 GRADING_RUBRIC 呼應）

## Test plan
- [x] 三個檔案存在且非空
- [x] 皆包含「時間切分」與「關鍵教學點」段落
- [x] 繁體中文、無編造 URL
- [x] 時間切分對應 S4/S5 的 120 分鐘、S6 的 60+50+10

🤖 Generated with [Claude Code](https://claude.com/claude-code)